### PR TITLE
docs: remove blank lines in CliCommand blocks to fix heading render

### DIFF
--- a/docs/en/docs/content/topics/create_topic.md
+++ b/docs/en/docs/content/topics/create_topic.md
@@ -65,16 +65,12 @@ longbridge topic create --body "Apple WWDC preview" --tickers AAPL.US
 <CliCommand>
 # Short post — plain text (default). Markdown is NOT rendered.
 longbridge topic create --body "Bullish on 700.HK today"
-
 # Short post with related tickers
 longbridge topic create --body "NVDA GTC highlights" --tickers NVDA.US,700.HK
-
 # Article — Markdown body, title is required
 longbridge topic create --title "My Analysis" --body "**Bullish** on 700.HK because..." --type article
-
 # Article from a Markdown file
 longbridge topic create --title "Q4 Earnings Preview" --body "$(cat analysis.md)" --type article
-
 # JSON output
 longbridge topic create --body "Test post" --format json
 </CliCommand>

--- a/docs/en/docs/content/topics/create_topic_reply.md
+++ b/docs/en/docs/content/topics/create_topic_reply.md
@@ -74,9 +74,7 @@ longbridge topic create-reply 6993508780031016960 --body "Great analysis!"
 <CliCommand>
 # Top-level reply
 longbridge topic create-reply 6993508780031016960 --body "Great analysis!"
-
 # Nested reply
-
 longbridge topic create-reply 6993508780031016960 --body "I agree." --reply-to 7001234567890123456
 </CliCommand>
 


### PR DESCRIPTION
 Blank lines inside <CliCommand> blocks caused markdown parser to
 interpret `# ...` comment lines as H1 headings instead of code comments.

<img width="763" height="456" alt="image" src="https://github.com/user-attachments/assets/a0b20d2b-55ab-44ef-8d01-86b1926acd2a" />

Removed the blank lines:
<img width="754" height="433" alt="image" src="https://github.com/user-attachments/assets/e67d0cfd-909c-47df-b675-6c894d7adc42" />
