### PR TITLE
feat: integrate Google One Tap login via CDN bundle

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,10 @@ const MCP_TOOLS_DATA_PATH = resolve(__dirname, 'data/mcp-tools.json')
 const regionCfg = getRegionConfig()
 const regionSrcExclude = computeSrcExclude(docsRoot)
 
+// Google One Tap：proxy 由环境变量 PROXY 控制（CI 与本地 dev:canary/build:canary 脚本显式注入），
+// 默认 production。放在 head 配置里，dev 与 build 都生效。
+const oneTapProxy = process.env.PROXY === 'canary' ? 'canary' : 'production'
+
 const insertScript = (html: string) => {
   const $ = cheerio.load(html)
   $('head').prepend(
@@ -159,6 +163,7 @@ export default defineConfig(
     gtag('config', 'G-P81Y8BDYYS');`],
     ['script', { defer: '', src: 'https://assets.lbkrs.com/pkg/sensorsdata/1.21.13.min.js' }],
     ['script', { async: '', src: 'https://at.alicdn.com/t/c/font_2621450_y740y72ffjq.js' }],
+    ['script', { src: 'https://assets.wbrks.com/plugin/session/google-one-tap.es.js', 'data-proxy': oneTapProxy }],
   ],
     themeConfig: {
       editLink: {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "private": true,
   "scripts": {
     "dev": "vitepress dev docs",
-    "dev:canary": "cross-env VITE_API_BASE_URL=https://openapi.longbridge.xyz npx vitepress dev docs",
+    "dev:canary": "cross-env PROXY=canary VITE_API_BASE_URL=https://openapi.longbridge.xyz npx vitepress dev docs",
     "dev:cn": "cross-env VITE_REGION=cn VITE_API_BASE_URL=https://openapi.longbridge.cn VITE_SITE_HOSTNAME=https://open.longbridge.cn npx vitepress dev docs",
-    "build:canary": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" VITE_API_BASE_URL=https://openapi.longbridge.xyz npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
+    "build:canary": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" PROXY=canary VITE_API_BASE_URL=https://openapi.longbridge.xyz npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
     "build:release": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" VITE_API_BASE_URL=https://openapi.longbridge.com npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
     "build:cn": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" VITE_REGION=cn VITE_API_BASE_URL=https://openapi.longbridge.cn VITE_PORTAL_GATEWAY_BASE_URL=https://m.lbkrs.com VITE_SITE_HOSTNAME=https://open.longbridge.cn npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
     "build:llms": "bun run scripts/normalize_md.ts && bun run scripts/generate-llms.ts",


### PR DESCRIPTION
Inject the `google-one-tap.es.js` CDN bundle into every page <head> via VitePress `head` config, so it loads in both `bun run dev` and built output (works around `transformHtml` being build-only).

- Gated by `VITE_REGION !== 'cn'` (Google unavailable in China).
- `data-proxy` attribute driven by `process.env.PROXY`: `canary` for `dev:canary` / `build:canary`, otherwise `production`. CI inherits via the same npm scripts — no workflow edits required.
- No `data-region` passed: the bundle falls back to `app-id` / `region` cookies with `sg` default, which is correct for this first-party `.longbridge.com` site.
- On success the bundle writes session cookies on `.longbridge.com` and reloads, so `longportInternal.isLogin()` picks it up.