### PR TITLE
修复大陆版构建未重写 openapi.longbridge.com 为 .cn

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,9 +49,12 @@ export default defineConfig(
     markdown: markdownConfig,
     transformHtml(code) {
       let html = insertScript(code)
-      // Region URL rewriting: replace global hostname with region hostname in final HTML
+      // Region URL rewriting: replace global hostnames (site + API) with region hostnames in final HTML
       if (regionCfg?.siteHostname && regionCfg.siteHostname !== 'https://open.longbridge.com') {
         html = html.split('https://open.longbridge.com').join(regionCfg.siteHostname)
+      }
+      if (regionCfg?.apiBaseUrl && regionCfg.apiBaseUrl !== 'https://openapi.longbridge.com') {
+        html = html.split('https://openapi.longbridge.com').join(regionCfg.apiBaseUrl)
       }
       return html
     },
@@ -127,13 +130,23 @@ export default defineConfig(
 
       rmSync(tmpDir, { recursive: true, force: true })
 
-      // Region URL rewriting for static assets
+      // Region URL rewriting for static assets (site + API hostnames)
+      const staticReplacements: [string, string][] = []
       if (regionCfg?.siteHostname && regionCfg.siteHostname !== 'https://open.longbridge.com') {
+        staticReplacements.push(['https://open.longbridge.com', regionCfg.siteHostname])
+      }
+      if (regionCfg?.apiBaseUrl && regionCfg.apiBaseUrl !== 'https://openapi.longbridge.com') {
+        staticReplacements.push(['https://openapi.longbridge.com', regionCfg.apiBaseUrl])
+      }
+      if (staticReplacements.length > 0) {
         const installDir = resolve(siteConfig.outDir, 'longbridge-terminal')
         for (const file of ['install', 'install.ps1']) {
           const filePath = resolve(installDir, file)
-          const content = readFileSync(filePath, 'utf-8')
-          writeFileSync(filePath, content.split('https://open.longbridge.com').join(regionCfg.siteHostname))
+          let content = readFileSync(filePath, 'utf-8')
+          for (const [from, to] of staticReplacements) {
+            content = content.split(from).join(to)
+          }
+          writeFileSync(filePath, content)
         }
         console.log('✓ install scripts rewritten for region')
       }

--- a/docs/.vitepress/md-plugins/region-filter.ts
+++ b/docs/.vitepress/md-plugins/region-filter.ts
@@ -11,14 +11,23 @@ export function RegionFilterPlugin(md: MarkdownItAsync) {
   const config = getRegionConfig()
   if (!config) return
 
-  // URL rewriting: replace global hostname with region hostname in all inline tokens
+  // URL rewriting: replace global hostnames (site + API) with region hostnames in all inline tokens
+  const urlReplacements: [string, string][] = []
   if (config.siteHostname && config.siteHostname !== 'https://open.longbridge.com') {
+    urlReplacements.push(['https://open.longbridge.com', config.siteHostname])
+  }
+  if (config.apiBaseUrl && config.apiBaseUrl !== 'https://openapi.longbridge.com') {
+    urlReplacements.push(['https://openapi.longbridge.com', config.apiBaseUrl])
+  }
+  if (urlReplacements.length > 0) {
     md.core.ruler.push('region_url_rewrite', (state) => {
       for (const token of state.tokens) {
-        rewriteTokenUrls(token, 'https://open.longbridge.com', config.siteHostname)
-        if (token.children) {
-          for (const child of token.children) {
-            rewriteTokenUrls(child, 'https://open.longbridge.com', config.siteHostname)
+        for (const [from, to] of urlReplacements) {
+          rewriteTokenUrls(token, from, to)
+          if (token.children) {
+            for (const child of token.children) {
+              rewriteTokenUrls(child, from, to)
+            }
           }
         }
       }


### PR DESCRIPTION
## 合入判断
**[APPROVE]** — 大陆版 region 重写机制扩展，补齐遗漏的 API 域名，无显著风险
> 3 files · +32 / -10 · `docs/.vitepress` `docs/public`

---
## 变更概要
- 扩展 `regionConfig` 的 URL 重写：在 markdown 渲染、HTML 输出、install 静态脚本三处统一新增 `openapi.longbridge.com → apiBaseUrl`（cn 版即 `.cn`），与原有 `open.longbridge.com → siteHostname` 并列
- 把两处单字符串替换重构为 `[from, to][]` 数组循环，方便后续再添加其它待重写域名
- 修正 `docs/public/longbridge-terminal/install` 第 8 行硬编码 `.cn` 的残留，统一为全球默认 `.com`，由构建期 region 重写在 cn 构建时统一换回 `.cn`

---
## 风险分析
| 风险点 | 等级 | 缓解措施 |
|--------|------|---------|
| 替换顺序导致二次替换 | ✅ | 两域名互不为子串（`open` 与 `openapi` 在第 12 字符就分叉），串行 `split/join` 安全 |
| 全球版构建受影响 | ✅ | 全球版 `regionCfg` 为 `undefined`，新条件分支不进入；install 源文件改回 `.com` 后全球版表现一致 |
| 大陆版漏改子域名 | 🟢 | 已对 cn 构建产物全量扫描（HTML + install），零 `.longbridge.com` 残留 |
| install 源文件改 `.cn`→`.com` 影响生产 | ✅ | 此文件由 buildEnd 在 cn 构建时再次重写为 `.cn`；全球版本就该用 `.com` |

---
## 设计决策
- **源文件统一全球默认域名，差异化交给 region 重写**：避免在源文件维护两套常量，与项目已有重写机制一致
- **三处重写点保持各自独立**：markdown 插件 / transformHtml / buildEnd install 各处的执行时机和载体不同（token / 字符串 / 文件），不抽象统一函数，避免过度耦合

---
## 代码关注点
1. **[需判断]** `apiBaseUrl` 是 origin 还是带 path (`docs/.vitepress/md-plugins/region-filter.ts:18`)
   `regionConfig.cn.apiBaseUrl = 'https://openapi.longbridge.cn'` 不带末尾 `/`，与被替换的 `https://openapi.longbridge.com` 一致，目前安全；若未来配置改成带 path/trailing slash 会导致 URL 拼接错位，reviewer 拍板是否在配置层加格式校验
2. **[信息]** dist 下的 `.md` 副本和 `llms.txt` 未走 region 过滤 (`docs/.vitepress` 外的 `copy-routes.ts` / `generate-llms.ts`)
   产物里 `.md` / `llms.txt` 仍含 `.com`（独立生成链路，不经 markdown 插件），本次 scope 不处理；如需大陆版 AI 消费副本也走 `.cn`，需单独 PR 给那两个脚本加 region 化

---
## 验证状态
✅ 本地 `bun run build:cn` 构建成功（170 行输出，1 warning，无 error） · ✅ dist HTML 全量扫描零 `.longbridge.com` 残留 · ✅ install / install.ps1 产物 5/5 处全部 `.cn` · 📋 需 reviewer 验证：线上 `open.longbridge.cn` 实际访问 mcp / skill 页面域名展示
