### PR TITLE
docs: Add CLI v0.22.2 release notes

### DIFF
--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -9,8 +9,7 @@ sidebar_icon: newspaper
 
 ### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
 
-- **JSON timestamps now RFC 3339** — `topics` (post and reply timestamps) and account P&L flow records output ISO 8601 / RFC 3339 datetimes instead of raw Unix epochs, consistent with every other command
-- **Cleaner JSON for `rank`, `screener`, `short-positions`, `top-movers`** — internal `counter_id` fields are replaced with the readable `symbol`; `rank` categories and `screener strategies` output is flattened and normalized (drops the `ib_` key prefix, adds `market` and strategy `type`)
+- **JSON timestamps now RFC 3339** — time-series and history commands (`kline`, `kline-history`, `trades`, `intraday`, `capital-flow`, `capital-dist`, `market-temp`, `topics`) and account P&L flows now output ISO 8601 / RFC 3339 datetimes instead of raw Unix epochs
 - **`market-temp --history` default range** — omitting `--start` now defaults to 30 days before the end date instead of today, so a single `--history` call returns a full month of data
 
 ### [v0.22.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.0)

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
+
+- **JSON timestamps now RFC 3339** — `topics` (post and reply timestamps) and account P&L flow records output ISO 8601 / RFC 3339 datetimes instead of raw Unix epochs, consistent with every other command
+- **Cleaner JSON for `rank`, `screener`, `short-positions`, `top-movers`** — internal `counter_id` fields are replaced with the readable `symbol`; `rank` categories and `screener strategies` output is flattened and normalized (drops the `ib_` key prefix, adds `market` and strategy `type`)
+- **`market-temp --history` default range** — omitting `--start` now defaults to 30 days before the end date instead of today, so a single `--history` call returns a full month of data
+
 ### [v0.22.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.0)
 
 - **New `shareholder --top`** — Top-20 major shareholders (institutions, individuals, insiders) with multi-period comparison; `--object-id <id>` for single shareholder holding history and trade details

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -9,8 +9,7 @@ sidebar_icon: newspaper
 
 ### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
 
-- **JSON 时间戳统一为 RFC 3339** — `topics`（帖子与回复时间）及账户盈亏流水记录现输出 ISO 8601 / RFC 3339 日期时间，不再使用原始 Unix 时间戳，与其他命令保持一致
-- **`rank`、`screener`、`short-positions`、`top-movers` JSON 输出优化** — 内部 `counter_id` 字段替换为可读的 `symbol`；`rank` 分类与 `screener strategies` 输出经扁平化与规范化处理（去除 `ib_` 键前缀，新增 `market` 与策略 `type`）
+- **JSON 时间戳统一为 RFC 3339** — 时序与历史类命令（`kline`、`kline-history`、`trades`、`intraday`、`capital-flow`、`capital-dist`、`market-temp`、`topics`）及账户盈亏流水现输出 ISO 8601 / RFC 3339 日期时间，不再使用原始 Unix 时间戳
 - **`market-temp --history` 默认区间** — 省略 `--start` 时默认取结束日期前 30 天（此前默认为当天），单次 `--history` 即可返回整月数据
 
 ### [v0.22.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.0)

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
+
+- **JSON 时间戳统一为 RFC 3339** — `topics`（帖子与回复时间）及账户盈亏流水记录现输出 ISO 8601 / RFC 3339 日期时间，不再使用原始 Unix 时间戳，与其他命令保持一致
+- **`rank`、`screener`、`short-positions`、`top-movers` JSON 输出优化** — 内部 `counter_id` 字段替换为可读的 `symbol`；`rank` 分类与 `screener strategies` 输出经扁平化与规范化处理（去除 `ib_` 键前缀，新增 `market` 与策略 `type`）
+- **`market-temp --history` 默认区间** — 省略 `--start` 时默认取结束日期前 30 天（此前默认为当天），单次 `--history` 即可返回整月数据
+
 ### [v0.22.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.0)
 
 - **新增 `shareholder --top`** — 前 20 大股东（机构、个人、内部人）多报告期持股对比；`--object-id <id>` 查看单一股东持仓历史及交易明细

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -9,8 +9,7 @@ sidebar_icon: newspaper
 
 ### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
 
-- **JSON 時間戳統一為 RFC 3339** — `topics`（帖子與回覆時間）及賬戶盈虧流水記錄現輸出 ISO 8601 / RFC 3339 日期時間，不再使用原始 Unix 時間戳，與其他命令保持一致
-- **`rank`、`screener`、`short-positions`、`top-movers` JSON 輸出優化** — 內部 `counter_id` 欄位替換為可讀的 `symbol`；`rank` 分類與 `screener strategies` 輸出經扁平化與規範化處理（去除 `ib_` 鍵前綴，新增 `market` 與策略 `type`）
+- **JSON 時間戳統一為 RFC 3339** — 時序與歷史類命令（`kline`、`kline-history`、`trades`、`intraday`、`capital-flow`、`capital-dist`、`market-temp`、`topics`）及賬戶盈虧流水現輸出 ISO 8601 / RFC 3339 日期時間，不再使用原始 Unix 時間戳
 - **`market-temp --history` 默認區間** — 省略 `--start` 時默認取結束日期前 30 天（此前默認為當天），單次 `--history` 即可返回整月數據
 
 ### [v0.22.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.0)

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,12 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
+
+- **JSON 時間戳統一為 RFC 3339** — `topics`（帖子與回覆時間）及賬戶盈虧流水記錄現輸出 ISO 8601 / RFC 3339 日期時間，不再使用原始 Unix 時間戳，與其他命令保持一致
+- **`rank`、`screener`、`short-positions`、`top-movers` JSON 輸出優化** — 內部 `counter_id` 欄位替換為可讀的 `symbol`；`rank` 分類與 `screener strategies` 輸出經扁平化與規範化處理（去除 `ib_` 鍵前綴，新增 `market` 與策略 `type`）
+- **`market-temp --history` 默認區間** — 省略 `--start` 時默認取結束日期前 30 天（此前默認為當天），單次 `--history` 即可返回整月數據
+
 ### [v0.22.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.0)
 
 - **新增 `shareholder --top`** — 前 20 大股東（機構、個人、內部人）多報告期持股對比；`--object-id <id>` 查看單一股東持倉歷史及交易明細


### PR DESCRIPTION
为 longbridge CLI v0.22.2 补充 Release Notes（en / zh-CN / zh-HK 三种语言）。

## 本次发布概要

v0.22.2 是一个聚焦 **JSON 输出一致性** 的维护版本，主要面向脚本与 AI 工具调用场景：

- **JSON 时间戳统一为 RFC 3339** — `topics`（帖子与回复时间）及账户盈亏流水记录改用 RFC 3339 日期时间，不再输出原始 Unix 时间戳（[#223](https://github.com/longbridge/longbridge-terminal/pull/223)、[#225](https://github.com/longbridge/longbridge-terminal/pull/225)）
- **`rank` / `screener` / `short-positions` / `top-movers` JSON 输出优化** — 内部 `counter_id` 替换为可读的 `symbol`，`rank` 分类与 `screener strategies` 输出扁平化、规范化（[#221](https://github.com/longbridge/longbridge-terminal/pull/221)）
- **`market-temp --history` 默认区间** — 省略 `--start` 时默认取结束日期前 30 天（[#224](https://github.com/longbridge/longbridge-terminal/pull/224)）

> 说明：v0.22.1（screener 迁移 AI 端点）此前未在 Release Notes 中单列，本次仅补充 v0.22.2。

🤖 Generated with [Claude Code](https://claude.com/claude-code)