### PR TITLE
docs: Add CLI v0.22.3 release notes

### DIFF
--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.3)
+
+- **`quote` now includes the US overnight session** — `quote <SYMBOL> --format json` now populates `overnight_quote` alongside `pre_market_quote` and `post_market_quote`; previously the overnight field was always `null`, skewing after-close analysis in AI workflows
+- **Account-type banner on holdings commands** — `positions`, `fund-positions`, `assets`, and `portfolio` now print a one-line banner (`Live A/C (real account)` / `Demo A/C (simulated account)`) before the table, so it's clear which account the data belongs to; `--format json` output is unchanged
+
 ### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
 
 - **JSON timestamps now RFC 3339** — time-series and history commands (`kline`, `kline-history`, `trades`, `intraday`, `capital-flow`, `capital-dist`, `market-temp`, `topics`) and account P&L flows now output ISO 8601 / RFC 3339 datetimes instead of raw Unix epochs

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.3)
+
+- **`quote` 新增美股隔夜时段数据** — `quote <SYMBOL> --format json` 现会输出 `overnight_quote`，与 `pre_market_quote`、`post_market_quote` 并列；此前隔夜字段始终为 `null`，会影响 AI 工作流中的盘后判断
+- **持仓类命令显示账户类型 banner** — `positions`、`fund-positions`、`assets`、`portfolio` 现会在表格前打印一行账户标识（`Live A/C (real account)` / `Demo A/C (simulated account)`），便于直接区分数据所属账户；`--format json` 输出保持不变
+
 ### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
 
 - **JSON 时间戳统一为 RFC 3339** — 时序与历史类命令（`kline`、`kline-history`、`trades`、`intraday`、`capital-flow`、`capital-dist`、`market-temp`、`topics`）及账户盈亏流水现输出 ISO 8601 / RFC 3339 日期时间，不再使用原始 Unix 时间戳

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.3)
+
+- **`quote` 新增美股隔夜時段數據** — `quote <SYMBOL> --format json` 現會輸出 `overnight_quote`，與 `pre_market_quote`、`post_market_quote` 並列；此前隔夜欄位始終為 `null`，會影響 AI 工作流中的盤後判斷
+- **持倉類命令顯示賬戶類型 banner** — `positions`、`fund-positions`、`assets`、`portfolio` 現會在表格前打印一行賬戶標識（`Live A/C (real account)` / `Demo A/C (simulated account)`），便於直接區分數據所屬賬戶；`--format json` 輸出保持不變
+
 ### [v0.22.2](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.2)
 
 - **JSON 時間戳統一為 RFC 3339** — 時序與歷史類命令（`kline`、`kline-history`、`trades`、`intraday`、`capital-flow`、`capital-dist`、`market-temp`、`topics`）及賬戶盈虧流水現輸出 ISO 8601 / RFC 3339 日期時間，不再使用原始 Unix 時間戳


### PR DESCRIPTION
为 longbridge CLI v0.22.3 补充 Release Notes（en / zh-CN / zh-HK 三种语言）。

## 本次发布概要

v0.22.3 聚焦面向 AI 工作流的输出可读性与完整性：

- **`quote` 新增美股隔夜时段数据** — `quote <SYMBOL> --format json` 现会填充 `overnight_quote`，与 `pre_market_quote`、`post_market_quote` 并列；此前隔夜字段始终为 `null`，会影响盘后判断（[#228](https://github.com/longbridge/longbridge-terminal/pull/228)）
- **持仓类命令显示账户类型 banner** — `positions`、`fund-positions`、`assets`、`portfolio` 现会在表格前打印一行账户标识（`Live A/C (real account)` / `Demo A/C (simulated account)`），便于直接区分数据所属账户；`--format json` 输出保持不变（[#226](https://github.com/longbridge/longbridge-terminal/pull/226)）

> 注：GitHub 上 v0.22.3 release 页面发布后，文档内的 tag 链接即可生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)