### PR TITLE
docs: Add CLI v0.22.4 release notes and ETF holdings docs

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -6,6 +6,26 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-06-04
+
+### CLI v0.22.4
+
+- **`constituent` now supports ETFs** — ETF symbols return an asset-allocation breakdown (holdings / regional / asset-class / industry); for US ETFs, the complete portfolio holdings are fetched from SEC EDGAR N-PORT filings by default (weight, shares, market value), with fallback to the platform's asset-allocation summary; index symbols behave exactly as before
+
+## 2026-06-03
+
+### CLI v0.22.3
+
+- **`quote` now includes the US overnight session** — `--format json` populates `overnight_quote` alongside `pre_market_quote` and `post_market_quote`, completing after-hours coverage for AI workflows
+- **Account-type banner on holdings commands** — `positions`, `fund-positions`, `assets`, and `portfolio` print a one-line banner (`Live A/C` / `Demo A/C`) before the table, making it clear which account the data belongs to
+
+## 2026-06-02
+
+### CLI v0.22.2
+
+- **JSON timestamps now RFC 3339** — time-series and history commands (`kline`, `trades`, `intraday`, `capital-flow`, etc.) and account P&L flows output ISO 8601 / RFC 3339 datetimes instead of raw Unix epochs, making JSON output directly consumable by AI agents and downstream tools
+- **`market-temp --history` default range** — omitting `--start` now returns a full month of data instead of a single day
+
 ## 2026-05-22
 
 ### CLI v0.22.0

--- a/docs/en/docs/cli/market-data/constituent.md
+++ b/docs/en/docs/cli/market-data/constituent.md
@@ -56,8 +56,41 @@ longbridge constituent HSI.HK --limit 10
 longbridge constituent SPX.US --limit 20 --sort inflow
 ```
 
+### View ETF holdings
+
+```bash
+longbridge constituent IVV.US
+longbridge constituent QQQ.US --limit 20
+```
+
+For ETF symbols, `constituent` switches to portfolio holdings instead of index constituents:
+
+- **US ETFs** — the complete portfolio is fetched from SEC EDGAR N-PORT filings by default, with each holding's name, CUSIP, weight, shares, and market value:
+
+```
+ETF Holdings — IVV.US (iShares Core S&P 500 ETF)
+Source: SEC N-PORT, report period 2026-03-31, filed 2026-05-28, 507 holdings
+
+| #  | name           | cusip     | weight | shares      | value(USD)     |
+|----|----------------|-----------|--------|-------------|----------------|
+| 1  | NVIDIA Corp.   | 67066G104 | 7.564% | 312,526,688 | 54,504,654,387 |
+| 2  | Apple, Inc.    | 037833100 | 6.650% | 188,816,321 | 47,919,694,106 |
+...
+... and 457 more (use --limit 0 for all)
+```
+
+- **Other ETFs** (or when SEC data is unavailable, e.g. UIT-structured funds like `SPY.US`) — falls back to the platform's asset-allocation breakdown, shown as four grouped tables: Holdings, Regional, Asset Class, and Industry.
+
+Notes:
+
+- N-PORT data is a fiscal-quarter-end snapshot filed with up to ~60 days' delay — authoritative but not real-time
+- `--limit` caps the holdings rows; `--limit 0` shows all; `--sort` / `--order` are ignored for pre-ranked holdings data
+- Index symbols (e.g. `HSI.HK`, `.SPX.US`) behave exactly as before
+
 ### JSON output
 
 ```bash
 longbridge constituent HSI.HK --format json
+# ETF holdings as structured JSON (full untruncated list)
+longbridge constituent IVV.US --format json
 ```

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.4)
+
+- **`constituent` now supports ETFs** — ETF symbols return an asset-allocation breakdown (holdings / regional / asset-class / industry tables); index symbols behave exactly as before
+- **Full US ETF holdings from SEC N-PORT** — for US ETFs, `constituent` fetches the complete portfolio from SEC EDGAR N-PORT filings by default (weight, shares, market value — e.g. all 500+ holdings of `IVV.US`); falls back to the platform's asset-allocation summary when SEC data is unavailable
+
 ### [v0.22.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.3)
 
 - **`quote` now includes the US overnight session** — `quote <SYMBOL> --format json` now populates `overnight_quote` alongside `pre_market_quote` and `post_market_quote`; previously the overnight field was always `null`, skewing after-close analysis in AI workflows

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -6,6 +6,26 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-06-04
+
+### CLI v0.22.4
+
+- **`constituent` 支持 ETF** — ETF 标的返回资产分布数据（持仓 / 地区 / 资产类别 / 行业）；美股 ETF 默认从 SEC EDGAR N-PORT 文件获取完整持仓组合（权重、股数、市值），SEC 数据不可用时回退到平台资产分布摘要；指数标的行为完全不变
+
+## 2026-06-03
+
+### CLI v0.22.3
+
+- **`quote` 新增美股隔夜时段数据** — `--format json` 输出 `overnight_quote`，与 `pre_market_quote`、`post_market_quote` 并列，补全 AI 工作流的盘后行情覆盖
+- **持仓类命令显示账户类型标识** — `positions`、`fund-positions`、`assets`、`portfolio` 在表格前打印一行账户标识（`Live A/C` / `Demo A/C`），直接区分数据所属账户
+
+## 2026-06-02
+
+### CLI v0.22.2
+
+- **JSON 时间戳改为 RFC 3339** — 时间序列和历史类命令（`kline`、`trades`、`intraday`、`capital-flow` 等）及账户盈亏流水输出 ISO 8601 / RFC 3339 日期时间，替代原始 Unix 时间戳，JSON 输出可直接被 AI Agent 和下游工具消费
+- **`market-temp --history` 默认范围** — 省略 `--start` 时返回完整一个月的数据，而非单日
+
 ## 2026-05-22
 
 ### CLI v0.22.0

--- a/docs/zh-CN/docs/cli/market-data/constituent.md
+++ b/docs/zh-CN/docs/cli/market-data/constituent.md
@@ -56,8 +56,41 @@ longbridge constituent HSI.HK --limit 10
 longbridge constituent SPX.US --limit 20 --sort inflow
 ```
 
+### 查看 ETF 持仓
+
+```bash
+longbridge constituent IVV.US
+longbridge constituent QQQ.US --limit 20
+```
+
+对于 ETF 标的，`constituent` 会切换为展示持仓组合，而非指数成分股：
+
+- **美股 ETF** — 默认从 SEC EDGAR N-PORT 文件获取完整持仓组合，包含每只持仓的名称、CUSIP、权重、股数和市值：
+
+```
+ETF Holdings — IVV.US (iShares Core S&P 500 ETF)
+Source: SEC N-PORT, report period 2026-03-31, filed 2026-05-28, 507 holdings
+
+| #  | name           | cusip     | weight | shares      | value(USD)     |
+|----|----------------|-----------|--------|-------------|----------------|
+| 1  | NVIDIA Corp.   | 67066G104 | 7.564% | 312,526,688 | 54,504,654,387 |
+| 2  | Apple, Inc.    | 037833100 | 6.650% | 188,816,321 | 47,919,694,106 |
+...
+... and 457 more (use --limit 0 for all)
+```
+
+- **其他 ETF**（或 SEC 数据不可用时，如 UIT 结构基金 `SPY.US`）— 回退到平台的资产分布数据，按持仓、地区、资产类别、行业四组表格展示。
+
+注意：
+
+- N-PORT 数据为财季末快照，申报最长可延迟约 60 天——是权威的完整持仓列表，但非实时数据
+- `--limit` 控制持仓行数；`--limit 0` 展示全部；对预先排序的持仓数据，`--sort` / `--order` 不生效
+- 指数标的（如 `HSI.HK`、`.SPX.US`）行为完全不变
+
 ### JSON 输出
 
 ```bash
 longbridge constituent HSI.HK --format json
+# ETF 持仓以结构化 JSON 输出（完整列表，不截断）
+longbridge constituent IVV.US --format json
 ```

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.4)
+
+- **`constituent` 支持 ETF** — ETF 标的现返回资产分布数据（持仓 / 地区 / 资产类别 / 行业四组表格）；指数标的行为完全不变
+- **美股 ETF 完整持仓（SEC N-PORT）** — 美股 ETF 默认从 SEC EDGAR N-PORT 文件获取完整持仓组合（权重、股数、市值，如 `IVV.US` 全部 500+ 只持仓）；SEC 数据不可用时回退到平台资产分布摘要
+
 ### [v0.22.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.3)
 
 - **`quote` 新增美股隔夜时段数据** — `quote <SYMBOL> --format json` 现会输出 `overnight_quote`，与 `pre_market_quote`、`post_market_quote` 并列；此前隔夜字段始终为 `null`，会影响 AI 工作流中的盘后判断

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -6,6 +6,26 @@ sidebar_position: 7
 sidebar_icon: newspaper
 ---
 
+## 2026-06-04
+
+### CLI v0.22.4
+
+- **`constituent` 支持 ETF** — ETF 標的返回資產分佈數據（持倉 / 地區 / 資產類別 / 行業）；美股 ETF 默認從 SEC EDGAR N-PORT 文件獲取完整持倉組合（權重、股數、市值），SEC 數據不可用時回退到平台資產分佈摘要；指數標的行為完全不變
+
+## 2026-06-03
+
+### CLI v0.22.3
+
+- **`quote` 新增美股隔夜時段數據** — `--format json` 輸出 `overnight_quote`，與 `pre_market_quote`、`post_market_quote` 並列，補全 AI 工作流的盤後行情覆蓋
+- **持倉類命令顯示賬戶類型標識** — `positions`、`fund-positions`、`assets`、`portfolio` 在表格前打印一行賬戶標識（`Live A/C` / `Demo A/C`），直接區分數據所屬賬戶
+
+## 2026-06-02
+
+### CLI v0.22.2
+
+- **JSON 時間戳改為 RFC 3339** — 時間序列和歷史類命令（`kline`、`trades`、`intraday`、`capital-flow` 等）及賬戶盈虧流水輸出 ISO 8601 / RFC 3339 日期時間，替代原始 Unix 時間戳，JSON 輸出可直接被 AI Agent 和下游工具消費
+- **`market-temp --history` 默認範圍** — 省略 `--start` 時返回完整一個月的數據，而非單日
+
 ## 2026-05-22
 
 ### CLI v0.22.0

--- a/docs/zh-HK/docs/cli/market-data/constituent.md
+++ b/docs/zh-HK/docs/cli/market-data/constituent.md
@@ -56,8 +56,41 @@ longbridge constituent HSI.HK --limit 10
 longbridge constituent SPX.US --limit 20 --sort inflow
 ```
 
+### 查看 ETF 持倉
+
+```bash
+longbridge constituent IVV.US
+longbridge constituent QQQ.US --limit 20
+```
+
+對於 ETF 標的，`constituent` 會切換為展示持倉組合，而非指數成份股：
+
+- **美股 ETF** — 默認從 SEC EDGAR N-PORT 文件獲取完整持倉組合，包含每隻持倉的名稱、CUSIP、權重、股數和市值：
+
+```
+ETF Holdings — IVV.US (iShares Core S&P 500 ETF)
+Source: SEC N-PORT, report period 2026-03-31, filed 2026-05-28, 507 holdings
+
+| #  | name           | cusip     | weight | shares      | value(USD)     |
+|----|----------------|-----------|--------|-------------|----------------|
+| 1  | NVIDIA Corp.   | 67066G104 | 7.564% | 312,526,688 | 54,504,654,387 |
+| 2  | Apple, Inc.    | 037833100 | 6.650% | 188,816,321 | 47,919,694,106 |
+...
+... and 457 more (use --limit 0 for all)
+```
+
+- **其他 ETF**（或 SEC 數據不可用時，如 UIT 結構基金 `SPY.US`）— 回退到平台的資產分佈數據，按持倉、地區、資產類別、行業四組表格展示。
+
+注意：
+
+- N-PORT 數據為財季末快照，申報最長可延遲約 60 天——是權威的完整持倉列表，但非實時數據
+- `--limit` 控制持倉行數；`--limit 0` 展示全部；對預先排序的持倉數據，`--sort` / `--order` 不生效
+- 指數標的（如 `HSI.HK`、`.SPX.US`）行為完全不變
+
 ### JSON 輸出
 
 ```bash
 longbridge constituent HSI.HK --format json
+# ETF 持倉以結構化 JSON 輸出（完整列表，不截斷）
+longbridge constituent IVV.US --format json
 ```

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,11 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.22.4](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.4)
+
+- **`constituent` 支持 ETF** — ETF 標的現返回資產分佈數據（持倉 / 地區 / 資產類別 / 行業四組表格）；指數標的行為完全不變
+- **美股 ETF 完整持倉（SEC N-PORT）** — 美股 ETF 默認從 SEC EDGAR N-PORT 文件獲取完整持倉組合（權重、股數、市值，如 `IVV.US` 全部 500+ 隻持倉）；SEC 數據不可用時回退到平台資產分佈摘要
+
 ### [v0.22.3](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.22.3)
 
 - **`quote` 新增美股隔夜時段數據** — `quote <SYMBOL> --format json` 現會輸出 `overnight_quote`，與 `pre_market_quote`、`post_market_quote` 並列；此前隔夜欄位始終為 `null`，會影響 AI 工作流中的盤後判斷


### PR DESCRIPTION
## Summary

- Add **CLI v0.22.4** release notes: `constituent` now supports ETFs — asset-allocation breakdown for ETF symbols, and full US ETF holdings fetched from SEC EDGAR N-PORT filings (longbridge/longbridge-terminal#229, longbridge/longbridge-terminal#231)
- Document the new ETF holdings behavior in the `constituent` command page (usage examples, SEC N-PORT output sample, fallback chain, data-timeliness notes)
- Backfill missing changelog entries for CLI v0.22.2 / v0.22.3, and add v0.22.4
- All three locales (en / zh-CN / zh-HK) updated in sync; Chinese docs formatted with `autocorrect --fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)