### PR TITLE
docs: Fix skill page Connect button to follow current locale

### DIFF
--- a/docs/.vitepress/theme/components/Skill.vue
+++ b/docs/.vitepress/theme/components/Skill.vue
@@ -1316,7 +1316,7 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
                   <span class="skill-hero-connect-step-num">{{ i + 1 }}</span>
                   <span>{{ step }}</span>
                 </div>
-                <a class="btn btn-dark" href="/connect" target="_self">
+                <a class="btn btn-dark" :href="localePfx + '/connect'" target="_self">
                   <svg
                     width="14"
                     height="14"


### PR DESCRIPTION
## Summary

- The `Connect AI` button on the `/skill` page hard-coded `href="/connect"`, so zh-CN / zh-HK visitors were sent to the English connect page.
- Now uses the existing `localePfx` computed (same as the `/skill/install` link), linking to `/zh-CN/connect` / `/zh-HK/connect` / `/connect` per the current locale. All three paths verified live (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)