### PR TITLE
docs: drop "100+" skill-count from homepage copy

### DIFF
--- a/docs/.vitepress/theme/components/NewHomePage/index.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/index.vue
@@ -33,7 +33,7 @@ const LOCALE = {
         label: 'AI Skill',
         title: 'Investment analysis agent for any AI',
         desc: 'Real-time quotes, portfolio data, news sentiment, and market intelligence — works with Claude, ChatGPT, Cursor, Gemini, Codex, Zed, Cherry Studio.',
-        tags: ['100+ Skills'],
+        tags: ['Agent Skills'],
       },
       {
         label: 'CLI',
@@ -79,7 +79,7 @@ const LOCALE = {
       cta: 'CLI Documentation',
     },
     ai: {
-      eyebrow: 'AI Skill · 100+ packaged tools',
+      eyebrow: 'AI Skill · packaged tools',
       title1: 'Unlock market insights, deep research,',
       title2: 'and intelligent trading for your AI.',
       desc: 'With Longbridge Skill, your AI assistant can screen stocks, decode earnings, track insider moves, and place orders — all in plain conversation, no app-switching required.',
@@ -214,7 +214,7 @@ const LOCALE = {
         label: 'AI Skill',
         title: '为任意 AI 打造的投资分析 Agent',
         desc: '实时行情、持仓数据、新闻情绪与市场洞察——兼容 Claude、ChatGPT、Cursor、Gemini、Codex、Zed、Cherry Studio。',
-        tags: ['100+ Skills'],
+        tags: ['Agent Skills'],
       },
       {
         label: 'CLI',
@@ -260,7 +260,7 @@ const LOCALE = {
       cta: 'CLI 文档',
     },
     ai: {
-      eyebrow: 'AI Skill · 100+ 预打包工具',
+      eyebrow: 'AI Skill · 预打包工具',
       title1: '为你的 AI 解锁市场洞察、',
       title2: '深度研究与智能交易',
       desc: '借助 Longbridge Skill，您的 AI 助手可以筛选股票、解读财报、追踪内部人交易、下达订单——全程对话完成，无需切换 App。',
@@ -378,7 +378,7 @@ const LOCALE = {
         label: 'AI Skill',
         title: '為任意 AI 打造的投資分析 Agent',
         desc: '即時行情、持倉數據、新聞情緒與市場洞察——兼容 Claude、ChatGPT、Cursor、Gemini、Codex、Zed、Cherry Studio。',
-        tags: ['100+ Skills'],
+        tags: ['Agent Skills'],
       },
       {
         label: 'CLI',
@@ -424,7 +424,7 @@ const LOCALE = {
       cta: 'CLI 文件',
     },
     ai: {
-      eyebrow: 'AI Skill · 100+ 預打包工具',
+      eyebrow: 'AI Skill · 預打包工具',
       title1: '為你的 AI 解鎖市場洞察、',
       title2: '深度研究與智能交易',
       desc: '借助 Longbridge Skill，您的 AI 助手可以篩選股票、解讀財報、追蹤內部人交易、下達訂單——全程對話完成，無需切換 App。',
@@ -1132,7 +1132,7 @@ const PRODUCTS = [
     label: 'AI Skill',
     title: 'Investment analysis agent for any AI',
     desc: 'Real-time quotes, portfolio data, news sentiment, and market intelligence — works with Claude, ChatGPT, Cursor, Gemini, Codex, Zed, Cherry Studio.',
-    tags: ['100+ Skills'],
+    tags: ['Agent Skills'],
     href: '/skill',
     accent: 'var(--lb-brand)',
   },

--- a/docs/.vitepress/theme/components/Skill.vue
+++ b/docs/.vitepress/theme/components/Skill.vue
@@ -44,7 +44,7 @@ const LOCALE = {
     catalog: {
       eyebrow: 'Skill catalog',
       badge: 'SKILL CATALOG',
-      title: '100+ Skills, covering every move in your trading day.',
+      title: 'Skills that cover every move in your trading day.',
       desc: 'Each Skill is a packaged set of tools, callable by any supported AI client. Click any card to see install instructions and details.',
       marketplace: 'Available on Claude Code Plugin Marketplace',
       pluginDesc: 'Copy the commands and run them in Claude Code.',
@@ -150,7 +150,7 @@ const LOCALE = {
     catalog: {
       eyebrow: 'Skill 目录',
       badge: 'SKILL 目录',
-      title: '100+ 个 Skill，覆盖您交易日的每一个动作',
+      title: '覆盖您交易日每一个动作的 Skill',
       desc: '每个 Skill 都是一套打包的工具集，可被任何受支持的 AI 客户端调用。点击任意卡片查看安装说明和详情。',
       marketplace: '已上架 Claude Code 插件市场',
       pluginDesc: '复制命令，在 Claude Code 中运行即可。',
@@ -381,7 +381,7 @@ const LOCALE = {
     catalog: {
       eyebrow: 'Skill 目錄',
       badge: 'SKILL 目錄',
-      title: '100+ 個 Skill，覆蓋您交易日的每一個動作。',
+      title: '覆蓋您交易日每一個動作的 Skill。',
       desc: '每個 Skill 都是一套打包的工具集，可被任何受支援的 AI 客戶端調用。點擊任意卡片查看安裝說明和詳情。',
       marketplace: '已上架 Claude Code 外掛市場',
       pluginDesc: '複製命令，在 Claude Code 中運行即可。',


### PR DESCRIPTION
## What

Removes the **"100+"** skill-count claims from the homepage copy.

## Why

The skills repo was consolidated from 127 skills down to 13. The raw count is no longer a selling point — quantity isn't the differentiator anymore, capability and coverage are. So the copy shouldn't lead with a number that is both outdated and off-message.

## Changes (all three locales: en / zh-CN / zh-HK)

- **`Skill.vue`** — catalog hero title: `100+ Skills, covering every move…` → `Skills that cover every move in your trading day.`
- **`NewHomePage/index.vue`**
  - AI Skill product-card `tags`: `['100+ Skills']` → `['Agent Skills']` (4 occurrences)
  - AI-section `eyebrow`: `AI Skill · 100+ packaged tools` → `AI Skill · packaged tools`

The CLI card's `130+ cmds` is a separate, still-valid metric and is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)