### PR TITLE
docs: update Codex MCP setup instructions

### DIFF
--- a/docs/en/docs/mcp.md
+++ b/docs/en/docs/mcp.md
@@ -78,6 +78,16 @@ Then open the `claude` terminal interface, type `/mcp`, select `longbridge`, and
 
 ### Codex
 
+Run the following command in your terminal:
+
+```bash
+codex mcp add longbridge --url https://mcp.longbridge.com
+```
+
+Then follow the OAuth authorization flow in Codex when prompted.
+
+#### Codex Desktop
+
 1. Click **Settings** (bottom right) → **MCP Servers** → **Add Server**
 2. In the "Connect to a custom MCP" screen, fill in:
    - Name: `longbridge`

--- a/docs/zh-CN/docs/mcp.md
+++ b/docs/zh-CN/docs/mcp.md
@@ -78,6 +78,16 @@ claude mcp add --transport http longbridge https://mcp.longbridge.com
 
 ### Codex
 
+在终端运行以下命令：
+
+```bash
+codex mcp add longbridge --url https://mcp.longbridge.com
+```
+
+随后在 Codex 中按提示完成 OAuth 授权流程。
+
+#### Codex Desktop
+
 1. 点击右下角 **Settings** → **MCP Servers** → **Add Server**
 2. 在 "Connect to a custom MCP" 界面填写：
    - Name：`longbridge`

--- a/docs/zh-HK/docs/mcp.md
+++ b/docs/zh-HK/docs/mcp.md
@@ -78,6 +78,16 @@ claude mcp add --transport http longbridge https://mcp.longbridge.com
 
 ### Codex
 
+在終端執行以下命令：
+
+```bash
+codex mcp add longbridge --url https://mcp.longbridge.com
+```
+
+隨後在 Codex 中按提示完成 OAuth 授權流程。
+
+#### Codex Desktop
+
 1. 點擊右下角 **Settings** → **MCP Servers** → **Add Server**
 2. 在 "Connect to a custom MCP" 介面填寫：
    - Name：`longbridge`


### PR DESCRIPTION
## Summary
- Update Codex MCP setup instructions to use `codex mcp add longbridge --url https://mcp.longbridge.com`.
- Preserve the existing UI setup flow as a Codex Desktop guide across English, Simplified Chinese, and Traditional Chinese docs.

## Test Plan
- `git diff --check -- docs/en/docs/mcp.md docs/zh-CN/docs/mcp.md docs/zh-HK/docs/mcp.md`
- `codex mcp add --help`
- `npx vitepress build docs --outDir /private/tmp/developers-docs-pr-build` (fails on existing `docs/superpowers/specs/2026-06-05-agent-auth-code-design.md:130` Vue parse error)
