### PR TITLE
fix(nav): preserve locale prefix on dashboard/log-out/connect links

### DIFF
--- a/docs/.vitepress/theme/components/AppNav.vue
+++ b/docs/.vitepress/theme/components/AppNav.vue
@@ -96,9 +96,9 @@ const avatarEl = ref<HTMLElement>()
 const avatarCloseTimer = ref<ReturnType<typeof setTimeout> | null>(null)
 
 const avatarMenuItems = computed(() => [
-  { title: 'Dashboard', href: '/dashboard' },
-  { title: 'Connect AI', href: '/connect' },
-  { title: 'Log out', href: '/log-out' },
+  { title: 'Dashboard', href: localePath('/dashboard') },
+  { title: 'Connect AI', href: localePath('/connect') },
+  { title: 'Log out', href: localePath('/log-out') },
 ])
 
 function onAvatarMouseEnter() {
@@ -284,7 +284,7 @@ onUnmounted(() => {
         <!-- Logged-in: Dashboard + Avatar -->
         <ClientOnly>
           <template v-if="isLogin">
-            <a class="btn btn-ghost btn-sm hidden md:inline-flex" target="_self" href="/dashboard">{{
+            <a class="btn btn-ghost btn-sm hidden md:inline-flex" target="_self" :href="localePath('/dashboard')">{{
               t('nav.dashboard')
             }}</a>
             <div

--- a/docs/.vitepress/theme/components/NewHomePage/HeroSection.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/HeroSection.vue
@@ -127,7 +127,7 @@ onUnmounted(() => clearInterval(productInterval))
 
       <!-- CTA Buttons -->
       <div class="hero-cta">
-        <a href="/dashboard" class="hero-btn-primary">
+        <a :href="localePath('/dashboard')" class="hero-btn-primary">
           {{ content.cta.getStarted }}
         </a>
         <a href="/docs/" class="hero-cta-secondary">

--- a/docs/.vitepress/theme/components/UserAvatar/index.vue
+++ b/docs/.vitepress/theme/components/UserAvatar/index.vue
@@ -43,11 +43,11 @@ const { avatar } = useAvatar()
 const list = computed<{ title: string; href: string }[]>(() => [
   {
     title: t('HD2WD-CgkkcJJW12yOmDM'),
-    href: '/dashboard',
+    href: localePath('/dashboard'),
   },
   {
     title: t('JJTHzcLZRxvS2W-2IwWMn'),
-    href: '/log-out',
+    href: localePath('/log-out'),
   },
 ])
 


### PR DESCRIPTION
切换到 zh-CN / zh-HK 后点击头像菜单 Dashboard 等链接，会丢失语言前缀跳到 /dashboard。 改为 localePath() 包裹，使其跟随当前 locale 输出 /zh-CN/dashboard、/zh-HK/dashboard。

涉及位置：UserAvatar 下拉、AppNav 头像菜单与顶栏 Dashboard 按钮、HeroSection CTA。