### PR TITLE
修复 terminal 安装脚本版本查询域名

### DIFF
--- a/docs/public/longbridge-terminal/install
+++ b/docs/public/longbridge-terminal/install
@@ -5,7 +5,7 @@ type curl > /dev/null || { echo "curl: not found"; exit 1; }
 repo='longbridge/longbridge-terminal'
 
 get_latest_release() {
-  tag=$(curl --silent "https://open.longbridge.cn/$repo/releases/latest")
+  tag=$(curl --silent "https://open.longbridge.com/$repo/releases/latest")
   if [ -z "$tag" ]; then
     echo "Failed to fetch the latest release." >&2
     return 1


### PR DESCRIPTION
## 合入判断
**[APPROVE]** — 单行域名对齐修复，无显著风险
> 1 file · +1 / -1 · `docs/public/longbridge-terminal`

---
## 变更概要
- 将 `install` 脚本中 `get_latest_release` 拉取最新版本所用的域名由 `open.longbridge.cn` 改为 `open.longbridge.com`
- 修复后与同目录 `install.ps1`（Windows 安装脚本）以及本脚本下方的 `download_url` 域名完全一致

---
## 风险分析
| 风险点 | 等级 | 缓解措施 |
|--------|------|---------|
| 旧域名是否仍可用 | ✅ | 不影响：脚本已统一指向 `.com`，与下载 URL 一致 |
| 用户已缓存旧 install 脚本 | 🟢 | 用户每次通过 `curl ... \| sh` 重新拉取，无持久缓存 |

---
## 设计决策
- **域名统一**：脚本内 `get_latest_release` 与 `download_url` 统一为 `open.longbridge.com`，与 PowerShell 版本保持一致

---
## 代码关注点
无显著问题。

---
## 验证状态
📋 需验证：在 macOS/Linux 上执行 `curl -fsSL https://open.longbridge.com/longbridge/longbridge-terminal/install | sh` 能成功拉取到最新版本号并完成下载
