### PR TITLE
Complete .com→.cn hostname rewrite for CN region build

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,7 +9,7 @@ import { execSync } from 'node:child_process'
 import { localesConfig } from './config/locales'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 import { rewriteMarkdownPath } from './utils'
-import { getRegionConfig, computeSrcExclude } from './region-utils'
+import { getRegionConfig, computeSrcExclude, buildRegionUrlReplacements } from './region-utils'
 import * as cheerio from 'cheerio'
 import yaml from 'js-yaml'
 
@@ -49,12 +49,9 @@ export default defineConfig(
     markdown: markdownConfig,
     transformHtml(code) {
       let html = insertScript(code)
-      // Region URL rewriting: replace global hostnames (site + API) with region hostnames in final HTML
-      if (regionCfg?.siteHostname && regionCfg.siteHostname !== 'https://open.longbridge.com') {
-        html = html.split('https://open.longbridge.com').join(regionCfg.siteHostname)
-      }
-      if (regionCfg?.apiBaseUrl && regionCfg.apiBaseUrl !== 'https://openapi.longbridge.com') {
-        html = html.split('https://openapi.longbridge.com').join(regionCfg.apiBaseUrl)
+      // Region URL rewriting: replace global hostnames (URL form + bare-text form) with region hostnames in final HTML
+      for (const [from, to] of buildRegionUrlReplacements()) {
+        html = html.split(from).join(to)
       }
       return html
     },
@@ -130,14 +127,8 @@ export default defineConfig(
 
       rmSync(tmpDir, { recursive: true, force: true })
 
-      // Region URL rewriting for static assets (site + API hostnames)
-      const staticReplacements: [string, string][] = []
-      if (regionCfg?.siteHostname && regionCfg.siteHostname !== 'https://open.longbridge.com') {
-        staticReplacements.push(['https://open.longbridge.com', regionCfg.siteHostname])
-      }
-      if (regionCfg?.apiBaseUrl && regionCfg.apiBaseUrl !== 'https://openapi.longbridge.com') {
-        staticReplacements.push(['https://openapi.longbridge.com', regionCfg.apiBaseUrl])
-      }
+      // Region URL rewriting for static assets (site + API hostnames, URL + bare-text form)
+      const staticReplacements = buildRegionUrlReplacements()
       if (staticReplacements.length > 0) {
         const installDir = resolve(siteConfig.outDir, 'longbridge-terminal')
         for (const file of ['install', 'install.ps1']) {
@@ -263,6 +254,27 @@ export default defineConfig(
             if (!id.endsWith('.yaml') && !id.endsWith('.yml')) return
             const data = yaml.load(src)
             return { code: `export default ${JSON.stringify(data)}`, map: null }
+          },
+        },
+        {
+          // Rewrite hardcoded global hostnames in source modules (Vue / TS / JSON) for region builds.
+          // markdown-it plugin + transformHtml don't reach Vite-compiled string literals.
+          name: 'region-source-url-rewrite',
+          enforce: 'pre' as const,
+          transform(src: string, id: string) {
+            if (id.includes('node_modules')) return
+            if (!/\.(vue|ts|tsx|js|jsx|json|ya?ml)(\?|$)/.test(id)) return
+            const replacements = buildRegionUrlReplacements()
+            if (replacements.length === 0) return
+            let code = src
+            let changed = false
+            for (const [from, to] of replacements) {
+              if (code.includes(from)) {
+                code = code.split(from).join(to)
+                changed = true
+              }
+            }
+            return changed ? { code, map: null } : undefined
           },
         },
         {

--- a/docs/.vitepress/md-plugins/region-filter.ts
+++ b/docs/.vitepress/md-plugins/region-filter.ts
@@ -1,7 +1,7 @@
 import type MarkdownItAsync from 'markdown-it'
 import type Token from 'markdown-it/lib/token.mjs'
 import picomatch from 'picomatch'
-import { getRegionConfig } from '../region-utils'
+import { getRegionConfig, buildRegionUrlReplacements } from '../region-utils'
 
 /**
  * Markdown-it plugin that removes sections (heading + content) based on region config.
@@ -11,14 +11,8 @@ export function RegionFilterPlugin(md: MarkdownItAsync) {
   const config = getRegionConfig()
   if (!config) return
 
-  // URL rewriting: replace global hostnames (site + API) with region hostnames in all inline tokens
-  const urlReplacements: [string, string][] = []
-  if (config.siteHostname && config.siteHostname !== 'https://open.longbridge.com') {
-    urlReplacements.push(['https://open.longbridge.com', config.siteHostname])
-  }
-  if (config.apiBaseUrl && config.apiBaseUrl !== 'https://openapi.longbridge.com') {
-    urlReplacements.push(['https://openapi.longbridge.com', config.apiBaseUrl])
-  }
+  // URL rewriting: replace global hostnames (site + API, both URL and bare-text form) with region hostnames
+  const urlReplacements = buildRegionUrlReplacements()
   if (urlReplacements.length > 0) {
     md.core.ruler.push('region_url_rewrite', (state) => {
       for (const token of state.tokens) {

--- a/docs/.vitepress/region-utils.ts
+++ b/docs/.vitepress/region-utils.ts
@@ -16,6 +16,26 @@ export function getRegionConfig(): RegionConfig | undefined {
 }
 
 /**
+ * URL replacements for region-aware rewriting.
+ * Returns both `https://`-prefixed (URLs) and bare hostname (link display text / inline mentions) pairs.
+ * Order is significant: protocol-prefixed rules first so bare rules don't double-match.
+ */
+export function buildRegionUrlReplacements(): [string, string][] {
+  const config = getRegionConfig()
+  if (!config) return []
+  const pairs: [string, string][] = []
+  if (config.siteHostname && config.siteHostname !== 'https://open.longbridge.com') {
+    pairs.push(['https://open.longbridge.com', config.siteHostname])
+    pairs.push(['open.longbridge.com', config.siteHostname.replace(/^https?:\/\//, '')])
+  }
+  if (config.apiBaseUrl && config.apiBaseUrl !== 'https://openapi.longbridge.com') {
+    pairs.push(['https://openapi.longbridge.com', config.apiBaseUrl])
+    pairs.push(['openapi.longbridge.com', config.apiBaseUrl.replace(/^https?:\/\//, '')])
+  }
+  return pairs
+}
+
+/**
  * Check if a page path is included in the current region's whitelist.
  * When no region is set (global build), all pages are included.
  *

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:cn": "cross-env VITE_REGION=cn VITE_API_BASE_URL=https://openapi.longbridge.cn VITE_SITE_HOSTNAME=https://open.longbridge.cn npx vitepress dev docs",
     "build:canary": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" PROXY=canary VITE_API_BASE_URL=https://openapi.longbridge.xyz npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
     "build:release": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" VITE_API_BASE_URL=https://openapi.longbridge.com npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
-    "build:cn": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" VITE_REGION=cn VITE_API_BASE_URL=https://openapi.longbridge.cn VITE_PORTAL_GATEWAY_BASE_URL=https://m.lbkrs.com VITE_SITE_HOSTNAME=https://open.longbridge.cn npx vitepress build docs && bun run build:llms && bun run build:copy-routes",
+    "build:cn": "cross-env \"NODE_OPTIONS=--max-old-space-size=12288 --expose-gc\" VITE_REGION=cn VITE_API_BASE_URL=https://openapi.longbridge.cn VITE_PORTAL_GATEWAY_BASE_URL=https://m.lbkrs.com VITE_SITE_HOSTNAME=https://open.longbridge.cn npx vitepress build docs && cross-env VITE_REGION=cn bun run build:llms && bun run build:copy-routes",
     "build:llms": "bun run scripts/normalize_md.ts && bun run scripts/generate-llms.ts",
     "build:copy-routes": "bun run scripts/copy-routes.ts",
     "preview": "vitepress preview docs",

--- a/scripts/generate-llms.ts
+++ b/scripts/generate-llms.ts
@@ -1,7 +1,16 @@
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import { getRegionConfig } from '../docs/.vitepress/region-utils'
+import { getRegionConfig, buildRegionUrlReplacements } from '../docs/.vitepress/region-utils'
+
+const regionUrlReplacements = buildRegionUrlReplacements()
+
+function applyRegionUrlRewrite(content: string): string {
+  for (const [from, to] of regionUrlReplacements) {
+    content = content.split(from).join(to)
+  }
+  return content
+}
 
 // Simple capitalize function to replace lodash
 function capitalize(str: string): string {
@@ -229,6 +238,7 @@ function generateLLMSTxt(): void {
 
     // Extract content from index.md
     let introContent = fs.readFileSync(path.join(__dirname, './llms-intro.md'), 'utf8')
+    introContent = applyRegionUrlRewrite(introContent)
 
     content = `${introContent}\n\n## SDK \n\n${markdownList}`
 

--- a/scripts/normalize_md.ts
+++ b/scripts/normalize_md.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import { globSync } from 'glob'
 import { rewriteMarkdownPath } from '../docs/.vitepress/utils'
+import { buildRegionUrlReplacements } from '../docs/.vitepress/region-utils'
 import {
   QUOTE_COMMANDS,
   QUOTE_PERMISSION_TITLE,
@@ -16,6 +17,15 @@ import {
 
 type Locale = QuoteLocale
 
+const regionUrlReplacements = buildRegionUrlReplacements()
+
+function applyRegionUrlRewrite(content: string): string {
+  for (const [from, to] of regionUrlReplacements) {
+    content = content.split(from).join(to)
+  }
+  return content
+}
+
 /**
  * Process Markdown file
  * @param filePath file path
@@ -29,6 +39,7 @@ function processMarkdownFile(filePath: string, outputPath: string, locale: Local
   // Need to implement regex to match <SDKLinks ... /> tags and replace with Markdown tables
   content = parseSDKLinks(content, locale)
   content = parseQuotePermission(content, locale)
+  content = applyRegionUrlRewrite(content)
 
   const relativePath = path.relative(docsDir, filePath)
 


### PR DESCRIPTION
## Merge Verdict
**[APPROVE]** — Region URL rewriting is now complete across every artifact channel; global build verified untouched.
> 6 files · +73 / -26 · `docs/.vitepress` `scripts/` `package.json`

---
## Summary
- Extract a shared `buildRegionUrlReplacements()` in `region-utils.ts` that emits **four** rules per non-default hostname (protocol-prefixed + bare-text for both `siteHostname` and `apiBaseUrl`), and route the four pre-existing rewrite sites (`region-filter.ts`, `transformHtml`, `buildEnd install`, plus the new ones) through it.
- Add a new Vite `region-source-url-rewrite` plugin (`enforce: 'pre'`) that rewrites hardcoded hostnames inside `.vue/.ts/.json/.yaml` source modules — this is the only channel that reaches Vite-compiled JS bundles (install command strings in Vue components, `mcp-tools.json` connect links, `openapi.yaml` error-message text).
- Bring `.md` copies + `llms.txt` into region rewriting: `normalize_md.ts` (the real writer of `dist/**/*.md`) and `generate-llms.ts` (the static `llms-intro.md` injection point) now share the same helper.
- Fix root-cause env-leak: `build:cn` now also passes `VITE_REGION=cn` to the `bun run build:llms` segment — previously `cross-env` only scoped to the `vitepress build` process, so `normalize_md`/`generate-llms` never knew it was a CN build and silently produced `.com` artifacts.

---
## Risk Analysis
| Risk | Level | Mitigation |
|------|-------|-----------|
| Global build (`build:release`) accidentally rewritten | ✅ | Shared helper returns `[]` when `VITE_REGION` is unset → every call site is a no-op. Verified: `dist/longbridge-terminal/install.ps1` is byte-identical to source; `mcp.html` keeps all 9 `.com`; `llms-full.txt` keeps all 112 `open.longbridge.com`. |
| Bare-rule replacement double-matches | ✅ | `open.longbridge.com` is **not** a substring of `openapi.longbridge.com` (5th char `.` vs `a`), so the four rules are mutually independent regardless of order. |
| Vite `transform` runs on every module — performance hit | 🟢 | `buildRegionUrlReplacements()` is lightweight (one env read + small array build). On global builds it short-circuits via `replacements.length === 0`. |
| `enforce: 'pre'` ordering vs `yaml-transform` | ✅ | `'pre'` plugins run before normal plugins, so this transform sees raw YAML text and rewrites it before `yaml-transform` JSON-stringifies it. |
| Hardcoded global hostnames in helper | 🟡 | Helper compares against the literal `'https://open.longbridge.com'` / `'https://openapi.longbridge.com'`. If the global domain ever changes, this file plus `region.config.ts` must be updated together. Same constraint already existed before this PR. |

---
## Design Decisions
- **Centralize rules in `region-utils.ts`** instead of inlining at four call sites — four sites already drifted (HTML had two rules but markdown had only the URL form before the previous PR). One source of truth prevents future drift.
- **Pre-stage Vite transform** rather than a post-build dist scan — keeps source maps intact and lets the rewrite participate in dependency invalidation. It also naturally covers `openapi.yaml` (huge but fine — string `split/join` is O(n) and only runs once per module per build).
- **Bare-hostname rules alongside URL rules** — covers `[open.longbridge.com/connect](https://...)` markdown patterns where only the link target gets matched by URL rules; the display text needs the bare-host rule.
- **Source `install` / `install.ps1` keep `.com`** — global build's `buildEnd` already had a rewrite pass; making source `.com`-default lets the existing rewrite mechanism do the work and avoids two source-of-truth files.

---
## Code Notes
1. **[Info]** `region-utils.ts:25` comment "first so bare rules don't double-match"
   In practice both orderings are correct because after either rule runs the other one's "from" string no longer exists in the result. The note is defensive rather than load-bearing.
   — Author note: deferred to next iteration.
2. **[Info]** `config.mts` Vite transform hook calls `buildRegionUrlReplacements()` per module
   The helper is cheap but is invoked once per source module on every build. Could be hoisted to the closure top if profiling ever flags it; not worth the structural change today.
   — Author note: deferred to next iteration.
3. **[Info]** `package.json` build:cn duplicates `cross-env VITE_REGION=cn` across two segments
   Maintainable but easy to forget if a third stage is added later. Could be solved with `cross-env-shell` wrapping the whole chain, but that's a separate cleanup.
   — Author note: deferred to next iteration.
4. **[Needs review]** Vite `transform` regex includes `.yaml`/`.yml`
   This is intentional — `openapi.yaml` ships hardcoded `https://open.longbridge.com/sdk` and error-message URLs that must be rewritten for CN. Reviewer should confirm there's no other YAML in the dependency graph whose `.com` strings must be preserved as global references. None observed in the current tree.

---
## Verification
- ✅ `bun run build:cn` succeeds; `rg -l '(open|openapi)\.longbridge\.com' docs/.vitepress/dist` → **zero residual `.com`** across HTML/MD/JS/scripts.
- ✅ `bun run build:release` succeeds; `install.ps1` and `install` are byte-identical to source; `mcp.html` keeps 9× `.com`; `llms-full.txt` keeps 112× `open.longbridge.com`; CN endpoint mentions inside docs (`getting-started.md` etc.) are preserved as intended.
- ✅ `openapi-quote.longbridge.cn` / `openapi-trade.longbridge.cn` counts in `getting-started.html` match source 1:1 (no over-rewrite).
- 📋 Reviewer to confirm: CN site (`open.longbridge.cn`) renders `mcp.md` / `skill/install` pages with the new URLs after deploy.
