### PR TITLE
Switch terminal install scripts to assets.lbkrs.com CDN

### DIFF
--- a/docs/public/longbridge-terminal/install
+++ b/docs/public/longbridge-terminal/install
@@ -5,7 +5,7 @@ type curl > /dev/null || { echo "curl: not found"; exit 1; }
 repo='longbridge/longbridge-terminal'
 
 get_latest_release() {
-  tag=$(curl --silent "https://open.longbridge.com/$repo/releases/latest")
+  tag=$(curl --silent "https://assets.lbkrs.com/github/release/longbridge-terminal/latest")
   if [ -z "$tag" ]; then
     echo "Failed to fetch the latest release." >&2
     return 1
@@ -47,7 +47,7 @@ if [ "$platform" = "linux" ]; then
   libc='-musl'
 fi
 
-download_url=https://open.longbridge.com/github/release/longbridge-terminal/$version/$package_name-$platform$libc-$arch.tar.gz
+download_url=https://assets.lbkrs.com/github/release/longbridge-terminal/$version/$package_name-$platform$libc-$arch.tar.gz
 echo $download_url
 
 tmp_dir=$(mktemp -d)

--- a/docs/public/longbridge-terminal/install.ps1
+++ b/docs/public/longbridge-terminal/install.ps1
@@ -14,7 +14,7 @@ $installDir  = Join-Path $env:LOCALAPPDATA 'Programs\longbridge'
 Write-Host "Fetching latest release..."
 
 try {
-    $version = (Invoke-WebRequest -Uri "https://open.longbridge.com/$repo/releases/latest" -UseBasicParsing -TimeoutSec 15).Content.Trim()
+    $version = (Invoke-WebRequest -Uri "https://assets.lbkrs.com/github/release/longbridge-terminal/latest" -UseBasicParsing -TimeoutSec 15).Content.Trim()
     if (-not $version) {
         throw "Failed to fetch the latest release."
     }
@@ -26,7 +26,7 @@ Write-Host "Latest release: $version"
 
 # ── Download ──────────────────────────────────────────────────────────────────
 
-$downloadUrl = "https://open.longbridge.com/github/release/longbridge-terminal/$version/$packageName-windows-amd64.zip"
+$downloadUrl = "https://assets.lbkrs.com/github/release/longbridge-terminal/$version/$packageName-windows-amd64.zip"
 
 Write-Host "Downloading $packageName@$version ..."
 Write-Host $downloadUrl


### PR DESCRIPTION
## Merge Verdict
**[APPROVE]** — Mechanical URL swap from `open.longbridge.com` to `assets.lbkrs.com` for terminal release lookup + download.
> 2 files · +4 / -4 · `docs/public/longbridge-terminal/`

---
## Summary
- `install` (POSIX) and `install.ps1` (PowerShell) both switched from `https://open.longbridge.com/...` to `https://assets.lbkrs.com/github/release/longbridge-terminal/...` for the latest-version probe and the binary tarball/zip download.
- Path layout also realigned: previously `/{repo}/releases/latest` with `repo=longbridge/longbridge-terminal`; now `/github/release/longbridge-terminal/latest` — a fixed path no longer parameterized by `$repo`.
- `$repo` variable is still declared in `install` but no longer used for URL construction (only referenced in code comments / future use); kept to minimize diff.

---
## Risk Analysis
| Risk | Level | Mitigation |
|------|-------|-----------|
| `assets.lbkrs.com/github/release/longbridge-terminal/latest` endpoint not yet live | 🟡 | Reviewer to confirm the new CDN endpoint is published before merging — script will fail at `get_latest_release` if the URL 404s |
| Existing users who already ran the old script | ✅ | They have `longbridge` on PATH; this PR only affects new installs / reinstalls |
| Region build interaction | ✅ | The CN region rewrite plugin (added in #1100) only rewrites `open.longbridge.com` / `openapi.longbridge.com`; `assets.lbkrs.com` is intentionally untouched and CN builds will keep the same CDN URL |
| `$repo` variable now unused | 🟢 | Cosmetic only — script still runs; removing it is a follow-up cleanup if desired |

---
## Design Decisions
- **Use a fixed path instead of `$repo`-templated**: The new endpoint is a dedicated CDN slot (`/github/release/longbridge-terminal/`) rather than a GitHub-mirror-style route, so the `$repo` indirection is no longer meaningful. Switching to a flat path matches the actual CDN layout.
- **Source file stays `assets.lbkrs.com` for all regions**: Unlike `open.longbridge.com`, the assets CDN is not region-split, so no region rewrite is needed; the file is identical for global and CN builds.

---
## Code Notes
1. **[Needs review]** Endpoint readiness on `assets.lbkrs.com/github/release/longbridge-terminal/latest`
   Reviewer should verify the CDN endpoint serves the latest version tag (and the per-version tarballs/zips) before merging; otherwise new installations will fail at the first `curl --silent` call.
2. **[Info]** `$repo='longbridge/longbridge-terminal'` left declared but unused in `install` (line 5)
   Not a bug — script still runs cleanly. Can be removed in a follow-up if the team prefers a tighter diff for future edits.
   — Author note: intentionally kept for now; will clean up in a follow-up.

---
## Verification
- ✅ Both files contain only the URL constants — no logic changes, no shell-substitution edge cases introduced.
- 📋 Manual check after merge: `curl -sSL https://assets.lbkrs.com/github/release/longbridge-terminal/install | sh` on Linux/macOS, and `iwr https://assets.lbkrs.com/longbridge/longbridge-terminal/install.ps1 | iex` on Windows.
- 📋 Confirm the CDN endpoint `assets.lbkrs.com/github/release/longbridge-terminal/latest` returns a version string with deploy ops.
