### PR TITLE
Rewrite mcp.longbridge.com to .cn for CN region build

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -15,9 +15,9 @@ import yaml from 'js-yaml'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const docsRoot = resolve(__dirname, '..')
-const MCP_TOOLS_URL = 'https://mcp.longbridge.com/mcp/tools.json'
 const MCP_TOOLS_DATA_PATH = resolve(__dirname, 'data/mcp-tools.json')
 const regionCfg = getRegionConfig()
+const MCP_TOOLS_URL = `${regionCfg?.mcpHostname || 'https://mcp.longbridge.com'}/mcp/tools.json`
 const regionSrcExclude = computeSrcExclude(docsRoot)
 
 // Google One Tap：proxy 由环境变量 PROXY 控制（CI 与本地 dev:canary/build:canary 脚本显式注入），

--- a/docs/.vitepress/region-utils.ts
+++ b/docs/.vitepress/region-utils.ts
@@ -32,6 +32,10 @@ export function buildRegionUrlReplacements(): [string, string][] {
     pairs.push(['https://openapi.longbridge.com', config.apiBaseUrl])
     pairs.push(['openapi.longbridge.com', config.apiBaseUrl.replace(/^https?:\/\//, '')])
   }
+  if (config.mcpHostname && config.mcpHostname !== 'https://mcp.longbridge.com') {
+    pairs.push(['https://mcp.longbridge.com', config.mcpHostname])
+    pairs.push(['mcp.longbridge.com', config.mcpHostname.replace(/^https?:\/\//, '')])
+  }
   return pairs
 }
 

--- a/region.config.ts
+++ b/region.config.ts
@@ -12,6 +12,8 @@ export interface RegionConfig {
   portalGatewayBaseUrl: string
   /** Site hostname for canonical URLs, sitemap, etc. */
   siteHostname: string
+  /** MCP server hostname for this region (used both for build-time tools fetch and runtime URLs shown to users) */
+  mcpHostname: string
   /**
    * Page whitelist — only pages matching these glob patterns are included.
    * Uses `**` prefix to match across all locale directories (en, zh-CN, zh-HK).
@@ -29,6 +31,7 @@ export const regionConfig: Record<string, RegionConfig> = {
     apiBaseUrl: 'https://openapi.longbridge.cn',
     portalGatewayBaseUrl: 'https://m.lbkrs.com',
     siteHostname: 'https://open.longbridge.cn',
+    mcpHostname: 'https://mcp.longbridge.cn',
 
     excludeNavLinks: ['/', '/docs/api', '/sdk'],
 


### PR DESCRIPTION
## Merge Verdict
**[APPROVE]** — Small, mechanical extension of the existing region rewrite to cover a third root domain (`mcp.longbridge.com`).
> 3 files · +8 / -1 · `region.config.ts` `docs/.vitepress/`

---
## Summary
- `region.config.ts`: `RegionConfig` interface gains a new required field `mcpHostname`; CN region sets it to `https://mcp.longbridge.cn`.
- `docs/.vitepress/region-utils.ts`: `buildRegionUrlReplacements()` emits a third pair of rules (URL + bare-text) for the MCP hostname — same shape as the existing `siteHostname` / `apiBaseUrl` blocks.
- `docs/.vitepress/config.mts`: `MCP_TOOLS_URL` (used by the `fetch-mcp-tools` build-time plugin) now resolves to `${regionCfg?.mcpHostname || 'https://mcp.longbridge.com'}/mcp/tools.json` — CN builds source the tool catalogue from the regional endpoint instead of `.com`.

---
## Risk Analysis
| Risk | Level | Mitigation |
|------|-------|-----------|
| `mcp.longbridge.cn/mcp/tools.json` endpoint not yet live | 🟡 | Reviewer to confirm before merge — `fetch-mcp-tools` will hard-fail the CN build if the URL 404s |
| Global build (`build:release`) regression | ✅ | Verified: with no `VITE_REGION`, `regionCfg` is undefined → helper returns `[]` for MCP rules; `MCP_TOOLS_URL` falls back to `mcp.longbridge.com`; `mcp.html` keeps 7 `.com` + 1 `.cn` (original "China mainland" section) identical to source |
| Order-dependent rewriting between `mcp` / `open` / `openapi` | ✅ | All three hostnames are mutually non-substring (different 5th char or different prefix), so the three protocol-prefixed + three bare-text rules are independent regardless of order |
| Mainland users on global `.cn` site getting wrong fallback | ✅ | This PR only adds a CN-only rule; nothing about the global path changes |

---
## Design Decisions
- **Add `mcpHostname` to `RegionConfig` rather than hardcoding inside the helper** — keeps the regional URL list in one declarative file (`region.config.ts`) instead of scattering string constants across `region-utils.ts`. Matches the pattern already set by `siteHostname` / `apiBaseUrl`.
- **Switch the build-time fetch source, not just the displayed URL** — chosen so the CN build's `mcp-tools.json` actually reflects the catalogue served by the CN MCP endpoint (potentially region-specific tools), instead of CN docs displaying `.cn` while embedded data was scraped from `.com`.
- **Field is required, not optional** — every region must declare its MCP hostname explicitly; prevents silent fallback to `.com` when a new region is added.

---
## Code Notes
1. **[Needs review]** Confirm `https://mcp.longbridge.cn/mcp/tools.json` is live and returns the same JSON shape as the global endpoint before merge. If not yet deployed, the CN build will fail at `fetch-mcp-tools` `buildStart` with an HTTP error.

---
## Verification
- ✅ `bun run build:cn` succeeds; `rg -l '(open|openapi|mcp)\.longbridge\.com' docs/.vitepress/dist` → zero residual `.com` across HTML / MD / JS / install scripts / `mcp-tools.json`.
- ✅ `bun run build:release` succeeds; `dist/docs/mcp.md` per-file domain distribution (1× `mcp.longbridge.cn` + 7× `mcp.longbridge.com`) matches source 1:1.
- ✅ Source `install.ps1` is byte-identical to global build output (no accidental rewrite).
