### PR TITLE
fix(docs): update calendar finance_calendar code examples and add mis…

### DIFF
--- a/docs/en/docs/cli/fundamentals/macrodata.md
+++ b/docs/en/docs/cli/fundamentals/macrodata.md
@@ -1,0 +1,53 @@
+---
+title: 'macrodata'
+sidebar_label: 'macrodata'
+sidebar_position: 5
+---
+
+# longbridge macrodata
+
+Query macroeconomic indicators and historical data. This is the indicator-dimension counterpart of `finance-calendar macrodata`: the same underlying data, organized by indicator instead of by release date.
+
+## Basic usage
+
+```bash
+# List all indicators
+longbridge macrodata
+
+# Filter by country and keyword
+longbridge macrodata --country US --keyword CPI
+
+# Query historical data for a single indicator
+longbridge macrodata US00175 --start 2024-01-01 --limit 12
+```
+
+## Examples
+
+### List all macroeconomic indicators
+
+```bash
+longbridge macrodata
+longbridge macrodata --country US
+longbridge macrodata --keyword CPI --country US
+```
+
+Output includes indicator code, name, category, country/region, release periodicity, and importance rank (1–3 stars).
+
+### Query historical releases
+
+```bash
+longbridge macrodata 61744 --start 2024-01-01 --limit 12 --format json
+```
+
+Returns actual, forecast, and previous values for each historical release of the indicator.
+
+## Common options
+
+| Option | Description |
+| ------ | ----------- |
+| `--country HK\|CN\|US\|EU\|JP\|SG` | List only indicators for the specified country/region |
+| `--keyword <KEYWORD>` | Filter indicators by keyword in their names |
+| `--start` / `--end` | Date range for historical data (YYYY-MM-DD) |
+| `--limit` / `--page` | Pagination; default 20 per page |
+| `--lang zh-CN\|en` | Language for indicator names and descriptions |
+| `--format json` | Structured output for scripting or AI agents |

--- a/docs/en/docs/market/calendar/dividend_calendar.md
+++ b/docs/en/docs/market/calendar/dividend_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar dividend --filter positions
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK method parameters.**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | Start date, YYYY-MM-DD |
-| end | string | YES | End date, YYYY-MM-DD |
-| market | string | NO | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                          |
+| ------ | ------ | -------- | ---------------------------------------------------- |
+| start  | string | YES      | Start date, YYYY-MM-DD                               |
+| end    | string | YES      | End date, YYYY-MM-DD                                 |
+| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar dividend --filter positions
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.dividend_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Dividend, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.dividend_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Dividend, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.dividend_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Dividend, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getDividendCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Dividend;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.dividend_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Dividend, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.dividend_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Dividend, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.DividendCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryDividend, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,10 +223,10 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
+        "date": "2026-06-30",
         "count": 275,
         "infos": [
           {
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
 | 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None   |
+| 400    | Bad request | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | false | Response date |
-| list | object[] | true | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                               |
+| ---- | -------- | -------- | ------------------------------------------------------------------------- |
+| date | string   | false    | Response date                                                             |
+| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | true | Date |
-| count | integer | false | Number of events on this date |
-| infos | object[] | true | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                                          |
+| ----- | -------- | -------- | -------------------------------------------------------------------- |
+| date  | string   | true     | Date                                                                 |
+| count | integer  | false    | Number of events on this date                                        |
+| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | false | Event ID |
-| symbol | string | false | Security symbol |
-| market | string | false | Market |
-| counter_name | string | false | Security name |
-| event_type | string | false | Event type |
-| activity_type | string | false | Activity type |
-| date | string | false | Event date |
-| datetime | string | false | Event datetime |
-| date_type | string | false | Date type |
-| content | string | false | Event content description |
-| currency | string | false | Currency |
-| star | integer | false | Importance rating (1-3) |
-| icon | string | false | Icon URL |
-| chart_uid | string | false | Chart identifier |
-| financial_market_time | string | false | Financial market time |
-| data_kv | object[] | false | Key-value data pairs |
+| Name                  | Type     | Required | Description               |
+| --------------------- | -------- | -------- | ------------------------- |
+| id                    | string   | false    | Event ID                  |
+| symbol                | string   | false    | Security symbol           |
+| market                | string   | false    | Market                    |
+| counter_name          | string   | false    | Security name             |
+| event_type            | string   | false    | Event type                |
+| activity_type         | string   | false    | Activity type             |
+| date                  | string   | false    | Event date                |
+| datetime              | string   | false    | Event datetime            |
+| date_type             | string   | false    | Date type                 |
+| content               | string   | false    | Event content description |
+| currency              | string   | false    | Currency                  |
+| star                  | integer  | false    | Importance rating (1-3)   |
+| icon                  | string   | false    | Icon URL                  |
+| chart_uid             | string   | false    | Chart identifier          |
+| financial_market_time | string   | false    | Financial market time     |
+| data_kv               | object[] | false    | Key-value data pairs      |

--- a/docs/en/docs/market/calendar/dividend_calendar.md
+++ b/docs/en/docs/market/calendar/dividend_calendar.md
@@ -14,7 +14,7 @@ Get upcoming and past dividend events including ex-date, pay date, and dividend 
 
 <CliCommand>
 longbridge finance-calendar dividend
-longbridge finance-calendar dividend --filter positions
+longbridge finance-calendar dividend --market US
 </CliCommand>
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />

--- a/docs/en/docs/market/calendar/earnings_calendar.md
+++ b/docs/en/docs/market/calendar/earnings_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar report --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK method parameters.**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | Start date, YYYY-MM-DD |
-| end | string | YES | End date, YYYY-MM-DD |
-| market | string | NO | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                          |
+| ------ | ------ | -------- | ---------------------------------------------------- |
+| start  | string | YES      | Start date, YYYY-MM-DD                               |
+| end    | string | YES      | End date, YYYY-MM-DD                                 |
+| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar report --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.earnings_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Report, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.earnings_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Report, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.earnings_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Report, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getEarningsCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Report;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.earnings_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Report, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.earnings_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Report, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.EarningsCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryReport, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,11 +223,11 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
-        "count": 2228,
+        "date": "2026-06-30",
+        "count": 1,
         "infos": [
           {
             "id": "12345",
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
 | 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None   |
+| 400    | Bad request | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | false | Response date |
-| list | object[] | true | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                               |
+| ---- | -------- | -------- | ------------------------------------------------------------------------- |
+| date | string   | false    | Response date                                                             |
+| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | true | Date |
-| count | integer | false | Number of events on this date |
-| infos | object[] | true | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                                          |
+| ----- | -------- | -------- | -------------------------------------------------------------------- |
+| date  | string   | true     | Date                                                                 |
+| count | integer  | false    | Number of events on this date                                        |
+| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | false | Event ID |
-| symbol | string | false | Security symbol |
-| market | string | false | Market |
-| counter_name | string | false | Security name |
-| event_type | string | false | Event type |
-| activity_type | string | false | Activity type |
-| date | string | false | Event date |
-| datetime | string | false | Event datetime |
-| date_type | string | false | Date type |
-| content | string | false | Event content description |
-| currency | string | false | Currency |
-| star | integer | false | Importance rating (1-3) |
-| icon | string | false | Icon URL |
-| chart_uid | string | false | Chart identifier |
-| financial_market_time | string | false | Financial market time |
-| data_kv | object[] | false | Key-value data pairs |
+| Name                  | Type     | Required | Description               |
+| --------------------- | -------- | -------- | ------------------------- |
+| id                    | string   | false    | Event ID                  |
+| symbol                | string   | false    | Security symbol           |
+| market                | string   | false    | Market                    |
+| counter_name          | string   | false    | Security name             |
+| event_type            | string   | false    | Event type                |
+| activity_type         | string   | false    | Activity type             |
+| date                  | string   | false    | Event date                |
+| datetime              | string   | false    | Event datetime            |
+| date_type             | string   | false    | Date type                 |
+| content               | string   | false    | Event content description |
+| currency              | string   | false    | Currency                  |
+| star                  | integer  | false    | Importance rating (1-3)   |
+| icon                  | string   | false    | Icon URL                  |
+| chart_uid             | string   | false    | Chart identifier          |
+| financial_market_time | string   | false    | Financial market time     |
+| data_kv               | object[] | false    | Key-value data pairs      |

--- a/docs/en/docs/market/calendar/ipo_calendar.md
+++ b/docs/en/docs/market/calendar/ipo_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar ipo --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK method parameters.**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | Start date, YYYY-MM-DD |
-| end | string | YES | End date, YYYY-MM-DD |
-| market | string | NO | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                          |
+| ------ | ------ | -------- | ---------------------------------------------------- |
+| start  | string | YES      | Start date, YYYY-MM-DD                               |
+| end    | string | YES      | End date, YYYY-MM-DD                                 |
+| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar ipo --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.ipo_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Ipo, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.ipo_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Ipo, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.ipo_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Ipo, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getIpoCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Ipo;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.ipo_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Ipo, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.ipo_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Ipo, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.IpoCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryIpo, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,10 +223,10 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-05-05",
+        "date": "2026-06-30",
         "count": 1,
         "infos": [
           {
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
 | 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None   |
+| 400    | Bad request | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | false | Response date |
-| list | object[] | true | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                               |
+| ---- | -------- | -------- | ------------------------------------------------------------------------- |
+| date | string   | false    | Response date                                                             |
+| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | true | Date |
-| count | integer | false | Number of events on this date |
-| infos | object[] | true | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                                          |
+| ----- | -------- | -------- | -------------------------------------------------------------------- |
+| date  | string   | true     | Date                                                                 |
+| count | integer  | false    | Number of events on this date                                        |
+| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | false | Event ID |
-| symbol | string | false | Security symbol |
-| market | string | false | Market |
-| counter_name | string | false | Security name |
-| event_type | string | false | Event type |
-| activity_type | string | false | Activity type |
-| date | string | false | Event date |
-| datetime | string | false | Event datetime |
-| date_type | string | false | Date type |
-| content | string | false | Event content description |
-| currency | string | false | Currency |
-| star | integer | false | Importance rating (1-3) |
-| icon | string | false | Icon URL |
-| chart_uid | string | false | Chart identifier |
-| financial_market_time | string | false | Financial market time |
-| data_kv | object[] | false | Key-value data pairs |
+| Name                  | Type     | Required | Description               |
+| --------------------- | -------- | -------- | ------------------------- |
+| id                    | string   | false    | Event ID                  |
+| symbol                | string   | false    | Security symbol           |
+| market                | string   | false    | Market                    |
+| counter_name          | string   | false    | Security name             |
+| event_type            | string   | false    | Event type                |
+| activity_type         | string   | false    | Activity type             |
+| date                  | string   | false    | Event date                |
+| datetime              | string   | false    | Event datetime            |
+| date_type             | string   | false    | Date type                 |
+| content               | string   | false    | Event content description |
+| currency              | string   | false    | Currency                  |
+| star                  | integer  | false    | Importance rating (1-3)   |
+| icon                  | string   | false    | Icon URL                  |
+| chart_uid             | string   | false    | Chart identifier          |
+| financial_market_time | string   | false    | Financial market time     |
+| data_kv               | object[] | false    | Key-value data pairs      |

--- a/docs/en/docs/market/calendar/macro_calendar.md
+++ b/docs/en/docs/market/calendar/macro_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar macrodata --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK method parameters.**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | Start date, YYYY-MM-DD |
-| end | string | YES | End date, YYYY-MM-DD |
-| market | string | NO | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                          |
+| ------ | ------ | -------- | ---------------------------------------------------- |
+| start  | string | YES      | Start date, YYYY-MM-DD                               |
+| end    | string | YES      | End date, YYYY-MM-DD                                 |
+| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar macrodata --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.macro_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.MacroData, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.content} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.macro_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.MacroData, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.content} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.macro_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.MacroData, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getMacroCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.MacroData;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.macro_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::MacroData, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.macro_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::MacroData, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.MacroCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMacroData, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,22 +223,22 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-05-02",
+        "date": "2026-06-30",
         "count": 0,
         "infos": [
           {
             "id": "12345",
-            "symbol": "AAPL.US",
+            "symbol": "",
             "market": "US",
-            "counter_name": "Apple Inc.",
+            "counter_name": "",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
-            "content": "",
+            "content": "US Core PPI MoM",
             "star": 0,
             "currency": "",
             "icon": "",
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
 | 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None   |
+| 400    | Bad request | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | false | Response date |
-| list | object[] | true | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                               |
+| ---- | -------- | -------- | ------------------------------------------------------------------------- |
+| date | string   | false    | Response date                                                             |
+| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | true | Date |
-| count | integer | false | Number of events on this date |
-| infos | object[] | true | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                                          |
+| ----- | -------- | -------- | -------------------------------------------------------------------- |
+| date  | string   | true     | Date                                                                 |
+| count | integer  | false    | Number of events on this date                                        |
+| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | false | Event ID |
-| symbol | string | false | Security symbol |
-| market | string | false | Market |
-| counter_name | string | false | Security name |
-| event_type | string | false | Event type |
-| activity_type | string | false | Activity type |
-| date | string | false | Event date |
-| datetime | string | false | Event datetime |
-| date_type | string | false | Date type |
-| content | string | false | Event content description |
-| currency | string | false | Currency |
-| star | integer | false | Importance rating (1-3) |
-| icon | string | false | Icon URL |
-| chart_uid | string | false | Chart identifier |
-| financial_market_time | string | false | Financial market time |
-| data_kv | object[] | false | Key-value data pairs |
+| Name                  | Type     | Required | Description               |
+| --------------------- | -------- | -------- | ------------------------- |
+| id                    | string   | false    | Event ID                  |
+| symbol                | string   | false    | Security symbol           |
+| market                | string   | false    | Market                    |
+| counter_name          | string   | false    | Security name             |
+| event_type            | string   | false    | Event type                |
+| activity_type         | string   | false    | Activity type             |
+| date                  | string   | false    | Event date                |
+| datetime              | string   | false    | Event datetime            |
+| date_type             | string   | false    | Date type                 |
+| content               | string   | false    | Event content description |
+| currency              | string   | false    | Currency                  |
+| star                  | integer  | false    | Importance rating (1-3)   |
+| icon                  | string   | false    | Icon URL                  |
+| chart_uid             | string   | false    | Chart identifier          |
+| financial_market_time | string   | false    | Financial market time     |
+| data_kv               | object[] | false    | Key-value data pairs      |

--- a/docs/en/docs/market/calendar/merge_calendar.md
+++ b/docs/en/docs/market/calendar/merge_calendar.md
@@ -12,18 +12,22 @@ headingLevel: 2
 
 Browse upcoming M&A and merger events.
 
-<SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
+<CliCommand>
+longbridge finance-calendar merge
+longbridge finance-calendar merge --market US
+</CliCommand>
 
+<SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
 ## Parameters
 
 > **SDK method parameters.**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | Start date, YYYY-MM-DD |
-| end | string | YES | End date, YYYY-MM-DD |
-| market | string | NO | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                          |
+| ------ | ------ | -------- | ---------------------------------------------------- |
+| start  | string | YES      | Start date, YYYY-MM-DD                               |
+| end    | string | YES      | End date, YYYY-MM-DD                                 |
+| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
 
 ## Request Example
 
@@ -31,14 +35,24 @@ Browse upcoming M&A and merger events.
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, CalendarCategory, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.finance_calendar(CalendarCategory.Merge, "2024-01-01", "2024-03-31")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Merge, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -46,14 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, CalendarCategory, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
-    resp = await ctx.finance_calendar(CalendarCategory.Merge, "2024-01-01", "2024-03-31")
-    print(resp)
+
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Merge, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -63,13 +90,15 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, CalendarCategory, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
-  const oauth = await OAuth.build('your-client-id', (_, url) => console.log('Open:', url))
+  const oauth = await OAuth.build('your-client-id', (_, url) => {
+    console.log('Open this URL to authorize: ' + url)
+  })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.financeCalendar(CalendarCategory.Merge, '2024-01-01', '2024-03-31')
+  const resp = await ctx.financeCalendar(CalendarCategory.Merge, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -84,10 +113,15 @@ import com.longbridge.calendar.*;
 
 class Main {
     public static void main(String[] args) throws Exception {
-        try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open: " + url)).get();
+        try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.financeCalendar(CalendarCategory.Merge, "2024-01-01", "2024-03-31", null).get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Merge;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -99,16 +133,41 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::{CalendarContext, CalendarCategory}, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.finance_calendar(CalendarCategory::Merge, "2024-01-01", "2024-03-31", None).await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Merge, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
+}
+```
+
+  </TabItem>
+  <TabItem value="cpp" label="C++">
+
+```cpp
+#include <iostream>
+#include <longbridge.hpp>
+
+using namespace longbridge;
+using namespace longbridge::calendar;
+
+int main() {
+    OAuthBuilder("your-client-id").build(
+        [](const std::string& url) { std::cout << "Open: " << url << std::endl; },
+        [](auto res) {
+            if (!res) return;
+            Config config = Config::from_oauth(*res);
+            CalendarContext ctx = CalendarContext::create(config);
+            ctx.finance_calendar(CalendarCategory::Merge, "2026-06-30", "2026-06-30", "US", [](auto resp) {
+                if (resp) std::cout << "OK" << std::endl;
+            });
+        });
+    std::cin.get();
 }
 ```
 
@@ -119,24 +178,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
+	"context"
+	"fmt"
+	"log"
 
-    "github.com/longbridge/openapi-go/calendar"
-    "github.com/longbridge/openapi-go/config"
-    "github.com/longbridge/openapi-go/oauth"
+	"github.com/longbridge/openapi-go/calendar"
+	"github.com/longbridge/openapi-go/config"
+	"github.com/longbridge/openapi-go/oauth"
 )
 
 func main() {
-    o := oauth.New("your-client-id").OnOpenURL(func(url string) { fmt.Println("Open:", url) })
-    if err := o.Build(context.Background()); err != nil { log.Fatal(err) }
-    conf, _ := config.New(config.WithOAuthClient(o))
-    c, _ := calendar.NewFromCfg(conf)
-    defer c.Close()
-    resp, err := c.FinanceCalendar(context.Background(), "Merge", "2024-01-01", "2024-03-31", nil)
-    if err != nil { log.Fatal(err) }
-    fmt.Printf("%+v\n", resp)
+	o := oauth.New("your-client-id").
+		OnOpenURL(func(url string) { fmt.Println("Open this URL to authorize:", url) })
+	if err := o.Build(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+	conf, err := config.New(config.WithOAuthClient(o))
+	if err != nil {
+		log.Fatal(err)
+	}
+	c, err := calendar.NewFromCfg(conf)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer c.Close()
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMerge, "2026-06-30", "2026-06-30", &market)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%+v\n", resp)
 }
 ```
 
@@ -145,10 +216,91 @@ func main() {
 
 ## Response
 
+### Response Example
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "date": "2026-06-30",
+    "list": [
+      {
+        "date": "2026-06-30",
+        "count": 1,
+        "infos": [
+          {
+            "id": "12345",
+            "symbol": "AAPL.US",
+            "market": "US",
+            "counter_name": "Apple Inc.",
+            "event_type": "",
+            "activity_type": "",
+            "date": "2026-06-30",
+            "datetime": "",
+            "content": "",
+            "star": 0,
+            "currency": "",
+            "icon": "",
+            "chart_uid": "",
+            "date_type": "",
+            "financial_market_time": "",
+            "data_kv": []
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | Success     | CalendarEventsResponse |
-| 400    | Bad request | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | Bad request | None                                              |
+
+## Schemas
+
+### CalendarEventsResponse
+
+<a id="CalendarEventsResponse"></a>
+
+| Name | Type     | Required | Description                                                               |
+| ---- | -------- | -------- | ------------------------------------------------------------------------- |
+| date | string   | false    | Response date                                                             |
+| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+
+### CalendarDateGroup
+
+<a id="CalendarDateGroup"></a>
+
+| Name  | Type     | Required | Description                                                          |
+| ----- | -------- | -------- | -------------------------------------------------------------------- |
+| date  | string   | true     | Date                                                                 |
+| count | integer  | false    | Number of events on this date                                        |
+| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+
+### CalendarEventInfo
+
+<a id="CalendarEventInfo"></a>
+
+| Name                  | Type     | Required | Description               |
+| --------------------- | -------- | -------- | ------------------------- |
+| id                    | string   | false    | Event ID                  |
+| symbol                | string   | false    | Security symbol           |
+| market                | string   | false    | Market                    |
+| counter_name          | string   | false    | Security name             |
+| event_type            | string   | false    | Event type                |
+| activity_type         | string   | false    | Activity type             |
+| date                  | string   | false    | Event date                |
+| datetime              | string   | false    | Event datetime            |
+| date_type             | string   | false    | Date type                 |
+| content               | string   | false    | Event content description |
+| currency              | string   | false    | Currency                  |
+| star                  | integer  | false    | Importance rating (1-3)   |
+| icon                  | string   | false    | Icon URL                  |
+| chart_uid             | string   | false    | Chart identifier          |
+| financial_market_time | string   | false    | Financial market time     |
+| data_kv               | object[] | false    | Key-value data pairs      |

--- a/docs/en/docs/market/calendar/split_calendar.md
+++ b/docs/en/docs/market/calendar/split_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar split --market HK
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK method parameters.**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | Start date, YYYY-MM-DD |
-| end | string | YES | End date, YYYY-MM-DD |
-| market | string | NO | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                          |
+| ------ | ------ | -------- | ---------------------------------------------------- |
+| start  | string | YES      | Start date, YYYY-MM-DD                               |
+| end    | string | YES      | End date, YYYY-MM-DD                                 |
+| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar split --market HK
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.split_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Split, "2026-06-30", "2026-06-30", "HK"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.split_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Split, "2026-06-30", "2026-06-30", "HK"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.split_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Split, '2026-06-30', '2026-06-30', 'HK')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getSplitCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Split;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "HK";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.split_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Split, "2026-06-30", "2026-06-30", Some("HK".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.split_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Split, "2026-06-30", "2026-06-30", "HK", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.SplitCalendar(context.Background(), "AAPL.US")
+	market := "HK"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategorySplit, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,20 +223,20 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
-        "count": 2228,
+        "date": "2026-06-30",
+        "count": 1,
         "infos": [
           {
             "id": "12345",
-            "symbol": "AAPL.US",
-            "market": "US",
-            "counter_name": "Apple Inc.",
+            "symbol": "0700.HK",
+            "market": "HK",
+            "counter_name": "Tencent Holdings",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
 | 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None   |
+| 400    | Bad request | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | false | Response date |
-| list | object[] | true | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                               |
+| ---- | -------- | -------- | ------------------------------------------------------------------------- |
+| date | string   | false    | Response date                                                             |
+| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | true | Date |
-| count | integer | false | Number of events on this date |
-| infos | object[] | true | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                                          |
+| ----- | -------- | -------- | -------------------------------------------------------------------- |
+| date  | string   | true     | Date                                                                 |
+| count | integer  | false    | Number of events on this date                                        |
+| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | false | Event ID |
-| symbol | string | false | Security symbol |
-| market | string | false | Market |
-| counter_name | string | false | Security name |
-| event_type | string | false | Event type |
-| activity_type | string | false | Activity type |
-| date | string | false | Event date |
-| datetime | string | false | Event datetime |
-| date_type | string | false | Date type |
-| content | string | false | Event content description |
-| currency | string | false | Currency |
-| star | integer | false | Importance rating (1-3) |
-| icon | string | false | Icon URL |
-| chart_uid | string | false | Chart identifier |
-| financial_market_time | string | false | Financial market time |
-| data_kv | object[] | false | Key-value data pairs |
+| Name                  | Type     | Required | Description               |
+| --------------------- | -------- | -------- | ------------------------- |
+| id                    | string   | false    | Event ID                  |
+| symbol                | string   | false    | Security symbol           |
+| market                | string   | false    | Market                    |
+| counter_name          | string   | false    | Security name             |
+| event_type            | string   | false    | Event type                |
+| activity_type         | string   | false    | Activity type             |
+| date                  | string   | false    | Event date                |
+| datetime              | string   | false    | Event datetime            |
+| date_type             | string   | false    | Date type                 |
+| content               | string   | false    | Event content description |
+| currency              | string   | false    | Currency                  |
+| star                  | integer  | false    | Importance rating (1-3)   |
+| icon                  | string   | false    | Icon URL                  |
+| chart_uid             | string   | false    | Chart identifier          |
+| financial_market_time | string   | false    | Financial market time     |
+| data_kv               | object[] | false    | Key-value data pairs      |

--- a/docs/zh-CN/docs/cli/fundamentals/macrodata.md
+++ b/docs/zh-CN/docs/cli/fundamentals/macrodata.md
@@ -1,0 +1,53 @@
+---
+title: 'macrodata'
+sidebar_label: 'macrodata'
+sidebar_position: 5
+---
+
+# longbridge macrodata
+
+按指标查询宏观经济数据，是 `finance-calendar macrodata` 的指标维度版本：同一数据源，但按指标组织而非按发布日期组织。
+
+## 基本用法
+
+```bash
+# 列出所有指标
+longbridge macrodata
+
+# 按国家和关键词筛选
+longbridge macrodata --country US --keyword CPI
+
+# 查询单个指标的历史数据
+longbridge macrodata US00175 --start 2024-01-01 --limit 12
+```
+
+## 示例
+
+### 列出所有宏观经济指标
+
+```bash
+longbridge macrodata
+longbridge macrodata --country US
+longbridge macrodata --keyword CPI --country US
+```
+
+输出包含指标代码、名称、分类、国家/地区、发布周期与重要性等级（1–3 星）。
+
+### 查询历史发布值
+
+```bash
+longbridge macrodata 61744 --start 2024-01-01 --limit 12 --format json
+```
+
+返回该指标每次发布时的实际值、预测值和前值。
+
+## 常用选项
+
+| 选项 | 说明 |
+| ---- | ---- |
+| `--country HK\|CN\|US\|EU\|JP\|SG` | 仅列出指定国家/地区的指标 |
+| `--keyword <KEYWORD>` | 按指标名称关键词筛选 |
+| `--start` / `--end` | 历史数据日期范围（YYYY-MM-DD） |
+| `--limit` / `--page` | 分页，默认每页 20 条 |
+| `--lang zh-CN\|en` | 指标名称与描述的语言 |
+| `--format json` | 结构化输出，便于脚本或 AI Agent 使用 |

--- a/docs/zh-CN/docs/market/calendar/dividend_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/dividend_calendar.md
@@ -14,7 +14,7 @@ headingLevel: 2
 
 <CliCommand>
 longbridge finance-calendar dividend
-longbridge finance-calendar dividend --filter positions
+longbridge finance-calendar dividend --market US
 </CliCommand>
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />

--- a/docs/zh-CN/docs/market/calendar/dividend_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/dividend_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar dividend --filter positions
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法参数。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 开始日期，格式 YYYY-MM-DD |
-| end | string | YES | 结束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar dividend --filter positions
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.dividend_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Dividend, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.dividend_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Dividend, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.dividend_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Dividend, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getDividendCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Dividend;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.dividend_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Dividend, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.dividend_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Dividend, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.DividendCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryDividend, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,10 +223,10 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
+        "date": "2026-06-30",
         "count": 275,
         "infos": [
           {
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 请求错误 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 响应日期 |
-| list | object[] | 是 | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 该日期的事件数量 |
-| infos | object[] | 是 | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 证券代码 |
-| market | string | 否 | 市场 |
-| counter_name | string | 否 | 证券名称 |
-| event_type | string | 否 | 事件类型 |
-| activity_type | string | 否 | 活动类型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件时间 |
-| date_type | string | 否 | 日期类型 |
-| content | string | 否 | 事件内容描述 |
-| currency | string | 否 | 货币 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 图标链接 |
-| chart_uid | string | 否 | 图表标识符 |
-| financial_market_time | string | 否 | 金融市场时间 |
-| data_kv | object[] | 否 | 键值数据对 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-CN/docs/market/calendar/earnings_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/earnings_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar report --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法参数。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 开始日期，格式 YYYY-MM-DD |
-| end | string | YES | 结束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar report --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.earnings_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Report, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.earnings_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Report, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.earnings_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Report, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getEarningsCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Report;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.earnings_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Report, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.earnings_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Report, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.EarningsCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryReport, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,11 +223,11 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
-        "count": 2228,
+        "date": "2026-06-30",
+        "count": 1,
         "infos": [
           {
             "id": "12345",
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 请求错误 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 响应日期 |
-| list | object[] | 是 | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 该日期的事件数量 |
-| infos | object[] | 是 | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 证券代码 |
-| market | string | 否 | 市场 |
-| counter_name | string | 否 | 证券名称 |
-| event_type | string | 否 | 事件类型 |
-| activity_type | string | 否 | 活动类型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件时间 |
-| date_type | string | 否 | 日期类型 |
-| content | string | 否 | 事件内容描述 |
-| currency | string | 否 | 货币 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 图标链接 |
-| chart_uid | string | 否 | 图表标识符 |
-| financial_market_time | string | 否 | 金融市场时间 |
-| data_kv | object[] | 否 | 键值数据对 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-CN/docs/market/calendar/ipo_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/ipo_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar ipo --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法参数。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 开始日期，格式 YYYY-MM-DD |
-| end | string | YES | 结束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar ipo --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.ipo_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Ipo, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.ipo_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Ipo, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.ipo_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Ipo, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getIpoCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Ipo;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.ipo_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Ipo, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.ipo_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Ipo, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.IpoCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryIpo, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,10 +223,10 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-05-05",
+        "date": "2026-06-30",
         "count": 1,
         "infos": [
           {
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 请求错误 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 响应日期 |
-| list | object[] | 是 | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 该日期的事件数量 |
-| infos | object[] | 是 | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 证券代码 |
-| market | string | 否 | 市场 |
-| counter_name | string | 否 | 证券名称 |
-| event_type | string | 否 | 事件类型 |
-| activity_type | string | 否 | 活动类型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件时间 |
-| date_type | string | 否 | 日期类型 |
-| content | string | 否 | 事件内容描述 |
-| currency | string | 否 | 货币 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 图标链接 |
-| chart_uid | string | 否 | 图表标识符 |
-| financial_market_time | string | 否 | 金融市场时间 |
-| data_kv | object[] | 否 | 键值数据对 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-CN/docs/market/calendar/macro_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/macro_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar macrodata --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法参数。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 开始日期，格式 YYYY-MM-DD |
-| end | string | YES | 结束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar macrodata --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.macro_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.MacroData, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.content} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.macro_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.MacroData, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.content} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.macro_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.MacroData, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getMacroCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.MacroData;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.macro_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::MacroData, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.macro_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::MacroData, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.MacroCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMacroData, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,22 +223,22 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-05-02",
+        "date": "2026-06-30",
         "count": 0,
         "infos": [
           {
             "id": "12345",
-            "symbol": "AAPL.US",
+            "symbol": "",
             "market": "US",
-            "counter_name": "Apple Inc.",
+            "counter_name": "",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
-            "content": "",
+            "content": "US Core PPI MoM",
             "star": 0,
             "currency": "",
             "icon": "",
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 请求错误 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 响应日期 |
-| list | object[] | 是 | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 该日期的事件数量 |
-| infos | object[] | 是 | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 证券代码 |
-| market | string | 否 | 市场 |
-| counter_name | string | 否 | 证券名称 |
-| event_type | string | 否 | 事件类型 |
-| activity_type | string | 否 | 活动类型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件时间 |
-| date_type | string | 否 | 日期类型 |
-| content | string | 否 | 事件内容描述 |
-| currency | string | 否 | 货币 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 图标链接 |
-| chart_uid | string | 否 | 图表标识符 |
-| financial_market_time | string | 否 | 金融市场时间 |
-| data_kv | object[] | 否 | 键值数据对 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-CN/docs/market/calendar/meeting_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/meeting_calendar.md
@@ -1,6 +1,6 @@
 ---
 slug: /market/calendar/meeting-calendar
-title: Meeting Calendar
+title: 股东大会日历
 sidebar_position: 6
 language_tabs: false
 toc_footers: []
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-Browse upcoming shareholder meetings and company events.
+浏览即将举行的股东大会及公司事件。
 
 <CliCommand>
 longbridge finance-calendar meeting
@@ -21,13 +21,13 @@ longbridge finance-calendar meeting --market US
 
 ## Parameters
 
-> **SDK method parameters.**
+> **SDK 方法参数。**
 
-| Name   | Type   | Required | Description                                          |
-| ------ | ------ | -------- | ---------------------------------------------------- |
-| start  | string | YES      | Start date, YYYY-MM-DD                               |
-| end    | string | YES      | End date, YYYY-MM-DD                                 |
-| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -258,8 +258,8 @@ func main() {
 
 | Status | Description | Schema                                            |
 | ------ | ----------- | ------------------------------------------------- |
-| 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None                                              |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -267,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type     | Required | Description                                                               |
-| ---- | -------- | -------- | ------------------------------------------------------------------------- |
-| date | string   | false    | Response date                                                             |
-| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name  | Type     | Required | Description                                                          |
-| ----- | -------- | -------- | -------------------------------------------------------------------- |
-| date  | string   | true     | Date                                                                 |
-| count | integer  | false    | Number of events on this date                                        |
-| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name                  | Type     | Required | Description               |
-| --------------------- | -------- | -------- | ------------------------- |
-| id                    | string   | false    | Event ID                  |
-| symbol                | string   | false    | Security symbol           |
-| market                | string   | false    | Market                    |
-| counter_name          | string   | false    | Security name             |
-| event_type            | string   | false    | Event type                |
-| activity_type         | string   | false    | Activity type             |
-| date                  | string   | false    | Event date                |
-| datetime              | string   | false    | Event datetime            |
-| date_type             | string   | false    | Date type                 |
-| content               | string   | false    | Event content description |
-| currency              | string   | false    | Currency                  |
-| star                  | integer  | false    | Importance rating (1-3)   |
-| icon                  | string   | false    | Icon URL                  |
-| chart_uid             | string   | false    | Chart identifier          |
-| financial_market_time | string   | false    | Financial market time     |
-| data_kv               | object[] | false    | Key-value data pairs      |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-CN/docs/market/calendar/merge_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/merge_calendar.md
@@ -1,7 +1,7 @@
 ---
-slug: /market/calendar/meeting-calendar
-title: Meeting Calendar
-sidebar_position: 6
+slug: /market/calendar/merge-calendar
+title: 合并日历
+sidebar_position: 7
 language_tabs: false
 toc_footers: []
 includes: []
@@ -10,24 +10,24 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-Browse upcoming shareholder meetings and company events.
+浏览即将发生的合并与并购事件。
 
 <CliCommand>
-longbridge finance-calendar meeting
-longbridge finance-calendar meeting --market US
+longbridge finance-calendar merge
+longbridge finance-calendar merge --market US
 </CliCommand>
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
 ## Parameters
 
-> **SDK method parameters.**
+> **SDK 方法参数。**
 
-| Name   | Type   | Required | Description                                          |
-| ------ | ------ | -------- | ---------------------------------------------------- |
-| start  | string | YES      | Start date, YYYY-MM-DD                               |
-| end    | string | YES      | End date, YYYY-MM-DD                                 |
-| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -47,7 +47,7 @@ config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
 resp = ctx.finance_calendar(
-    CalendarCategory.Meeting, "2026-06-30", "2026-06-30", "US"
+    CalendarCategory.Merge, "2026-06-30", "2026-06-30", "US"
 )
 
 for group in resp.list:
@@ -75,7 +75,7 @@ async def main() -> None:
     ctx = AsyncCalendarContext.create(config)
 
     resp = await ctx.finance_calendar(
-        CalendarCategory.Meeting, "2026-06-30", "2026-06-30", "US"
+        CalendarCategory.Merge, "2026-06-30", "2026-06-30", "US"
     )
 
     for group in resp.list:
@@ -98,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.financeCalendar(CalendarCategory.Meeting, '2026-06-30', '2026-06-30', 'US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Merge, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -117,7 +117,7 @@ class Main {
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
             FinanceCalendarOptions opts = new FinanceCalendarOptions();
-            opts.category = CalendarCategory.Meeting;
+            opts.category = CalendarCategory.Merge;
             opts.start = "2026-06-30";
             opts.end = "2026-06-30";
             opts.market = "US";
@@ -140,7 +140,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.finance_calendar(CalendarCategory::Meeting, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Merge, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -163,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.finance_calendar(CalendarCategory::Meeting, "2026-06-30", "2026-06-30", "US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Merge, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -203,7 +203,7 @@ func main() {
 	}
 	defer c.Close()
 	market := "US"
-	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMeeting, "2026-06-30", "2026-06-30", &market)
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMerge, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -258,8 +258,8 @@ func main() {
 
 | Status | Description | Schema                                            |
 | ------ | ----------- | ------------------------------------------------- |
-| 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None                                              |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -267,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type     | Required | Description                                                               |
-| ---- | -------- | -------- | ------------------------------------------------------------------------- |
-| date | string   | false    | Response date                                                             |
-| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name  | Type     | Required | Description                                                          |
-| ----- | -------- | -------- | -------------------------------------------------------------------- |
-| date  | string   | true     | Date                                                                 |
-| count | integer  | false    | Number of events on this date                                        |
-| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name                  | Type     | Required | Description               |
-| --------------------- | -------- | -------- | ------------------------- |
-| id                    | string   | false    | Event ID                  |
-| symbol                | string   | false    | Security symbol           |
-| market                | string   | false    | Market                    |
-| counter_name          | string   | false    | Security name             |
-| event_type            | string   | false    | Event type                |
-| activity_type         | string   | false    | Activity type             |
-| date                  | string   | false    | Event date                |
-| datetime              | string   | false    | Event datetime            |
-| date_type             | string   | false    | Date type                 |
-| content               | string   | false    | Event content description |
-| currency              | string   | false    | Currency                  |
-| star                  | integer  | false    | Importance rating (1-3)   |
-| icon                  | string   | false    | Icon URL                  |
-| chart_uid             | string   | false    | Chart identifier          |
-| financial_market_time | string   | false    | Financial market time     |
-| data_kv               | object[] | false    | Key-value data pairs      |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-CN/docs/market/calendar/split_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/split_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar split --market HK
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法参数。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 开始日期，格式 YYYY-MM-DD |
-| end | string | YES | 结束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 开始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 结束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市场筛选：US、HK、SH、SZ，不填则返回所有市场 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar split --market HK
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.split_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Split, "2026-06-30", "2026-06-30", "HK"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.split_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Split, "2026-06-30", "2026-06-30", "HK"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.split_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Split, '2026-06-30', '2026-06-30', 'HK')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getSplitCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Split;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "HK";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.split_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Split, "2026-06-30", "2026-06-30", Some("HK".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.split_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Split, "2026-06-30", "2026-06-30", "HK", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.SplitCalendar(context.Background(), "AAPL.US")
+	market := "HK"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategorySplit, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,20 +223,20 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
-        "count": 2228,
+        "date": "2026-06-30",
+        "count": 1,
         "infos": [
           {
             "id": "12345",
-            "symbol": "AAPL.US",
-            "market": "US",
-            "counter_name": "Apple Inc.",
+            "symbol": "0700.HK",
+            "market": "HK",
+            "counter_name": "Tencent Holdings",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 请求错误 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 请求错误    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 响应日期 |
-| list | object[] | 是 | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 响应日期                                                     |
+| list | object[] | 是       | 日历日期分组列表，见 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 该日期的事件数量 |
-| infos | object[] | 是 | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 该日期的事件数量                                         |
+| infos | object[] | 是       | 日历事件列表，见 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 证券代码 |
-| market | string | 否 | 市场 |
-| counter_name | string | 否 | 证券名称 |
-| event_type | string | 否 | 事件类型 |
-| activity_type | string | 否 | 活动类型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件时间 |
-| date_type | string | 否 | 日期类型 |
-| content | string | 否 | 事件内容描述 |
-| currency | string | 否 | 货币 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 图标链接 |
-| chart_uid | string | 否 | 图表标识符 |
-| financial_market_time | string | 否 | 金融市场时间 |
-| data_kv | object[] | 否 | 键值数据对 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 证券代码         |
+| market                | string   | 否       | 市场             |
+| counter_name          | string   | 否       | 证券名称         |
+| event_type            | string   | 否       | 事件类型         |
+| activity_type         | string   | 否       | 活动类型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件时间         |
+| date_type             | string   | 否       | 日期类型         |
+| content               | string   | 否       | 事件内容描述     |
+| currency              | string   | 否       | 货币             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 图标链接         |
+| chart_uid             | string   | 否       | 图表标识符       |
+| financial_market_time | string   | 否       | 金融市场时间     |
+| data_kv               | object[] | 否       | 键值数据对       |

--- a/docs/zh-HK/docs/cli/fundamentals/macrodata.md
+++ b/docs/zh-HK/docs/cli/fundamentals/macrodata.md
@@ -1,0 +1,53 @@
+---
+title: 'macrodata'
+sidebar_label: 'macrodata'
+sidebar_position: 5
+---
+
+# longbridge macrodata
+
+按指標查詢宏觀經濟數據，是 `finance-calendar macrodata` 的指標維度版本：同一數據源，但按指標組織而非按發布日期組織。
+
+## 基本用法
+
+```bash
+# 列出所有指標
+longbridge macrodata
+
+# 按國家和關鍵詞篩選
+longbridge macrodata --country US --keyword CPI
+
+# 查詢單個指標的歷史數據
+longbridge macrodata US00175 --start 2024-01-01 --limit 12
+```
+
+## 示例
+
+### 列出所有宏觀經濟指標
+
+```bash
+longbridge macrodata
+longbridge macrodata --country US
+longbridge macrodata --keyword CPI --country US
+```
+
+輸出包含指標代碼、名稱、分類、國家/地區、發布週期與重要性等級（1–3 星）。
+
+### 查詢歷史發布值
+
+```bash
+longbridge macrodata 61744 --start 2024-01-01 --limit 12 --format json
+```
+
+返回該指標每次發布時的實際值、預測值和前值。
+
+## 常用選項
+
+| 選項 | 說明 |
+| ---- | ---- |
+| `--country HK\|CN\|US\|EU\|JP\|SG` | 僅列出指定國家/地區的指標 |
+| `--keyword <KEYWORD>` | 按指標名稱關鍵詞篩選 |
+| `--start` / `--end` | 歷史數據日期範圍（YYYY-MM-DD） |
+| `--limit` / `--page` | 分頁，預設每頁 20 條 |
+| `--lang zh-CN\|en` | 指標名稱與描述的語言 |
+| `--format json` | 結構化輸出，便於腳本或 AI Agent 使用 |

--- a/docs/zh-HK/docs/market/calendar/dividend_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/dividend_calendar.md
@@ -14,7 +14,7 @@ headingLevel: 2
 
 <CliCommand>
 longbridge finance-calendar dividend
-longbridge finance-calendar dividend --filter positions
+longbridge finance-calendar dividend --market US
 </CliCommand>
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />

--- a/docs/zh-HK/docs/market/calendar/dividend_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/dividend_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar dividend --filter positions
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法參數。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 開始日期，格式 YYYY-MM-DD |
-| end | string | YES | 結束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar dividend --filter positions
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.dividend_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Dividend, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.dividend_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Dividend, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.dividend_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Dividend, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getDividendCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Dividend;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.dividend_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Dividend, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.dividend_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Dividend, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.DividendCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryDividend, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,10 +223,10 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
+        "date": "2026-06-30",
         "count": 275,
         "infos": [
           {
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 請求錯誤 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 響應日期 |
-| list | object[] | 是 | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 該日期的事件數量 |
-| infos | object[] | 是 | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 證券代碼 |
-| market | string | 否 | 市場 |
-| counter_name | string | 否 | 證券名稱 |
-| event_type | string | 否 | 事件類型 |
-| activity_type | string | 否 | 活動類型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件時間 |
-| date_type | string | 否 | 日期類型 |
-| content | string | 否 | 事件內容描述 |
-| currency | string | 否 | 貨幣 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 圖標鏈接 |
-| chart_uid | string | 否 | 圖表標識符 |
-| financial_market_time | string | 否 | 金融市場時間 |
-| data_kv | object[] | 否 | 鍵值數據對 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |

--- a/docs/zh-HK/docs/market/calendar/earnings_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/earnings_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar report --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法參數。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 開始日期，格式 YYYY-MM-DD |
-| end | string | YES | 結束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar report --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.earnings_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Report, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.earnings_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Report, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.earnings_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Report, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getEarningsCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Report;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.earnings_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Report, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.earnings_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Report, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.EarningsCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryReport, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,11 +223,11 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
-        "count": 2228,
+        "date": "2026-06-30",
+        "count": 1,
         "infos": [
           {
             "id": "12345",
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 請求錯誤 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 響應日期 |
-| list | object[] | 是 | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 該日期的事件數量 |
-| infos | object[] | 是 | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 證券代碼 |
-| market | string | 否 | 市場 |
-| counter_name | string | 否 | 證券名稱 |
-| event_type | string | 否 | 事件類型 |
-| activity_type | string | 否 | 活動類型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件時間 |
-| date_type | string | 否 | 日期類型 |
-| content | string | 否 | 事件內容描述 |
-| currency | string | 否 | 貨幣 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 圖標鏈接 |
-| chart_uid | string | 否 | 圖表標識符 |
-| financial_market_time | string | 否 | 金融市場時間 |
-| data_kv | object[] | 否 | 鍵值數據對 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |

--- a/docs/zh-HK/docs/market/calendar/ipo_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/ipo_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar ipo --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法參數。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 開始日期，格式 YYYY-MM-DD |
-| end | string | YES | 結束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar ipo --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.ipo_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Ipo, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.ipo_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Ipo, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.ipo_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Ipo, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getIpoCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Ipo;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.ipo_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Ipo, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.ipo_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Ipo, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.IpoCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryIpo, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,10 +223,10 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-05-05",
+        "date": "2026-06-30",
         "count": 1,
         "infos": [
           {
@@ -210,7 +236,7 @@ func main() {
             "counter_name": "Apple Inc.",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 請求錯誤 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 響應日期 |
-| list | object[] | 是 | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 該日期的事件數量 |
-| infos | object[] | 是 | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 證券代碼 |
-| market | string | 否 | 市場 |
-| counter_name | string | 否 | 證券名稱 |
-| event_type | string | 否 | 事件類型 |
-| activity_type | string | 否 | 活動類型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件時間 |
-| date_type | string | 否 | 日期類型 |
-| content | string | 否 | 事件內容描述 |
-| currency | string | 否 | 貨幣 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 圖標鏈接 |
-| chart_uid | string | 否 | 圖表標識符 |
-| financial_market_time | string | 否 | 金融市場時間 |
-| data_kv | object[] | 否 | 鍵值數據對 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |

--- a/docs/zh-HK/docs/market/calendar/macro_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/macro_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar macrodata --market US
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法參數。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 開始日期，格式 YYYY-MM-DD |
-| end | string | YES | 結束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar macrodata --market US
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.macro_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.MacroData, "2026-06-30", "2026-06-30", "US"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.content} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.macro_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.MacroData, "2026-06-30", "2026-06-30", "US"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.content} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.macro_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.MacroData, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getMacroCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.MacroData;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "US";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.macro_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::MacroData, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.macro_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::MacroData, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.MacroCalendar(context.Background(), "AAPL.US")
+	market := "US"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMacroData, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,22 +223,22 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-05-02",
+        "date": "2026-06-30",
         "count": 0,
         "infos": [
           {
             "id": "12345",
-            "symbol": "AAPL.US",
+            "symbol": "",
             "market": "US",
-            "counter_name": "Apple Inc.",
+            "counter_name": "",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
-            "content": "",
+            "content": "US Core PPI MoM",
             "star": 0,
             "currency": "",
             "icon": "",
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 請求錯誤 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 響應日期 |
-| list | object[] | 是 | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 該日期的事件數量 |
-| infos | object[] | 是 | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 證券代碼 |
-| market | string | 否 | 市場 |
-| counter_name | string | 否 | 證券名稱 |
-| event_type | string | 否 | 事件類型 |
-| activity_type | string | 否 | 活動類型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件時間 |
-| date_type | string | 否 | 日期類型 |
-| content | string | 否 | 事件內容描述 |
-| currency | string | 否 | 貨幣 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 圖標鏈接 |
-| chart_uid | string | 否 | 圖表標識符 |
-| financial_market_time | string | 否 | 金融市場時間 |
-| data_kv | object[] | 否 | 鍵值數據對 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |

--- a/docs/zh-HK/docs/market/calendar/meeting_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/meeting_calendar.md
@@ -1,6 +1,6 @@
 ---
 slug: /market/calendar/meeting-calendar
-title: Meeting Calendar
+title: 股東大會日曆
 sidebar_position: 6
 language_tabs: false
 toc_footers: []
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-Browse upcoming shareholder meetings and company events.
+瀏覽即將舉行的股東大會及公司事件。
 
 <CliCommand>
 longbridge finance-calendar meeting
@@ -21,13 +21,13 @@ longbridge finance-calendar meeting --market US
 
 ## Parameters
 
-> **SDK method parameters.**
+> **SDK 方法參數。**
 
-| Name   | Type   | Required | Description                                          |
-| ------ | ------ | -------- | ---------------------------------------------------- |
-| start  | string | YES      | Start date, YYYY-MM-DD                               |
-| end    | string | YES      | End date, YYYY-MM-DD                                 |
-| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -258,8 +258,8 @@ func main() {
 
 | Status | Description | Schema                                            |
 | ------ | ----------- | ------------------------------------------------- |
-| 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None                                              |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -267,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type     | Required | Description                                                               |
-| ---- | -------- | -------- | ------------------------------------------------------------------------- |
-| date | string   | false    | Response date                                                             |
-| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name  | Type     | Required | Description                                                          |
-| ----- | -------- | -------- | -------------------------------------------------------------------- |
-| date  | string   | true     | Date                                                                 |
-| count | integer  | false    | Number of events on this date                                        |
-| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name                  | Type     | Required | Description               |
-| --------------------- | -------- | -------- | ------------------------- |
-| id                    | string   | false    | Event ID                  |
-| symbol                | string   | false    | Security symbol           |
-| market                | string   | false    | Market                    |
-| counter_name          | string   | false    | Security name             |
-| event_type            | string   | false    | Event type                |
-| activity_type         | string   | false    | Activity type             |
-| date                  | string   | false    | Event date                |
-| datetime              | string   | false    | Event datetime            |
-| date_type             | string   | false    | Date type                 |
-| content               | string   | false    | Event content description |
-| currency              | string   | false    | Currency                  |
-| star                  | integer  | false    | Importance rating (1-3)   |
-| icon                  | string   | false    | Icon URL                  |
-| chart_uid             | string   | false    | Chart identifier          |
-| financial_market_time | string   | false    | Financial market time     |
-| data_kv               | object[] | false    | Key-value data pairs      |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |

--- a/docs/zh-HK/docs/market/calendar/merge_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/merge_calendar.md
@@ -1,7 +1,7 @@
 ---
-slug: /market/calendar/meeting-calendar
-title: Meeting Calendar
-sidebar_position: 6
+slug: /market/calendar/merge-calendar
+title: 合併日曆
+sidebar_position: 7
 language_tabs: false
 toc_footers: []
 includes: []
@@ -10,24 +10,24 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-Browse upcoming shareholder meetings and company events.
+瀏覽即將發生的合併與併購事件。
 
 <CliCommand>
-longbridge finance-calendar meeting
-longbridge finance-calendar meeting --market US
+longbridge finance-calendar merge
+longbridge finance-calendar merge --market US
 </CliCommand>
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
 ## Parameters
 
-> **SDK method parameters.**
+> **SDK 方法參數。**
 
-| Name   | Type   | Required | Description                                          |
-| ------ | ------ | -------- | ---------------------------------------------------- |
-| start  | string | YES      | Start date, YYYY-MM-DD                               |
-| end    | string | YES      | End date, YYYY-MM-DD                                 |
-| market | string | NO       | Market filter: `US`, `HK`, `SH`, `SZ`. Omit for all. |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -47,7 +47,7 @@ config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
 resp = ctx.finance_calendar(
-    CalendarCategory.Meeting, "2026-06-30", "2026-06-30", "US"
+    CalendarCategory.Merge, "2026-06-30", "2026-06-30", "US"
 )
 
 for group in resp.list:
@@ -75,7 +75,7 @@ async def main() -> None:
     ctx = AsyncCalendarContext.create(config)
 
     resp = await ctx.finance_calendar(
-        CalendarCategory.Meeting, "2026-06-30", "2026-06-30", "US"
+        CalendarCategory.Merge, "2026-06-30", "2026-06-30", "US"
     )
 
     for group in resp.list:
@@ -98,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.financeCalendar(CalendarCategory.Meeting, '2026-06-30', '2026-06-30', 'US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Merge, '2026-06-30', '2026-06-30', 'US')
   console.log(resp)
 }
 main().catch(console.error)
@@ -117,7 +117,7 @@ class Main {
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
             FinanceCalendarOptions opts = new FinanceCalendarOptions();
-            opts.category = CalendarCategory.Meeting;
+            opts.category = CalendarCategory.Merge;
             opts.start = "2026-06-30";
             opts.end = "2026-06-30";
             opts.market = "US";
@@ -140,7 +140,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.finance_calendar(CalendarCategory::Meeting, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Merge, "2026-06-30", "2026-06-30", Some("US".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -163,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.finance_calendar(CalendarCategory::Meeting, "2026-06-30", "2026-06-30", "US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Merge, "2026-06-30", "2026-06-30", "US", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -203,7 +203,7 @@ func main() {
 	}
 	defer c.Close()
 	market := "US"
-	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMeeting, "2026-06-30", "2026-06-30", &market)
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategoryMerge, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -258,8 +258,8 @@ func main() {
 
 | Status | Description | Schema                                            |
 | ------ | ----------- | ------------------------------------------------- |
-| 200    | Success     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | Bad request | None                                              |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -267,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type     | Required | Description                                                               |
-| ---- | -------- | -------- | ------------------------------------------------------------------------- |
-| date | string   | false    | Response date                                                             |
-| list | object[] | true     | List of calendar date groups, see [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name  | Type     | Required | Description                                                          |
-| ----- | -------- | -------- | -------------------------------------------------------------------- |
-| date  | string   | true     | Date                                                                 |
-| count | integer  | false    | Number of events on this date                                        |
-| infos | object[] | true     | List of calendar events, see [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name                  | Type     | Required | Description               |
-| --------------------- | -------- | -------- | ------------------------- |
-| id                    | string   | false    | Event ID                  |
-| symbol                | string   | false    | Security symbol           |
-| market                | string   | false    | Market                    |
-| counter_name          | string   | false    | Security name             |
-| event_type            | string   | false    | Event type                |
-| activity_type         | string   | false    | Activity type             |
-| date                  | string   | false    | Event date                |
-| datetime              | string   | false    | Event datetime            |
-| date_type             | string   | false    | Date type                 |
-| content               | string   | false    | Event content description |
-| currency              | string   | false    | Currency                  |
-| star                  | integer  | false    | Importance rating (1-3)   |
-| icon                  | string   | false    | Icon URL                  |
-| chart_uid             | string   | false    | Chart identifier          |
-| financial_market_time | string   | false    | Financial market time     |
-| data_kv               | object[] | false    | Key-value data pairs      |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |

--- a/docs/zh-HK/docs/market/calendar/split_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/split_calendar.md
@@ -19,16 +19,15 @@ longbridge finance-calendar split --market HK
 
 <SDKLinks module="calendar" klass="CalendarContext" method="finance_calendar" />
 
-
 ## Parameters
 
 > **SDK 方法參數。**
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| start | string | YES | 開始日期，格式 YYYY-MM-DD |
-| end | string | YES | 結束日期，格式 YYYY-MM-DD |
-| market | string | NO | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
+| Name   | Type   | Required | Description                                  |
+| ------ | ------ | -------- | -------------------------------------------- |
+| start  | string | YES      | 開始日期，格式 YYYY-MM-DD                    |
+| end    | string | YES      | 結束日期，格式 YYYY-MM-DD                    |
+| market | string | NO       | 市場篩選：US、HK、SH、SZ，不填則返回所有市場 |
 
 ## Request Example
 
@@ -36,14 +35,24 @@ longbridge finance-calendar split --market HK
   <TabItem value="python" label="Python">
 
 ```python
-from longbridge.openapi import CalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    CalendarCategory,
+    CalendarContext,
+    Config,
+    OAuthBuilder,
+)
 
 oauth = OAuthBuilder("your-client-id").build(lambda url: print("Visit:", url))
 config = Config.from_oauth(oauth)
 ctx = CalendarContext(config)
 
-resp = ctx.split_calendar("AAPL.US")
-print(resp)
+resp = ctx.finance_calendar(
+    CalendarCategory.Split, "2026-06-30", "2026-06-30", "HK"
+)
+
+for group in resp.list:
+    for info in group.infos:
+        print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 ```
 
   </TabItem>
@@ -51,15 +60,27 @@ print(resp)
 
 ```python
 import asyncio
-from longbridge.openapi import AsyncCalendarContext, Config, OAuthBuilder
+from longbridge.openapi import (
+    AsyncCalendarContext,
+    CalendarCategory,
+    Config,
+    OAuthBuilder,
+)
 
 async def main() -> None:
-    oauth = await OAuthBuilder("your-client-id").build_async(lambda url: print("Visit:", url))
+    oauth = await OAuthBuilder("your-client-id").build_async(
+        lambda url: print("Visit:", url)
+    )
     config = Config.from_oauth(oauth)
     ctx = AsyncCalendarContext.create(config)
 
-    resp = await ctx.split_calendar("AAPL.US")
-    print(resp)
+    resp = await ctx.finance_calendar(
+        CalendarCategory.Split, "2026-06-30", "2026-06-30", "HK"
+    )
+
+    for group in resp.list:
+        for info in group.infos:
+            print(f"  - {info.symbol:12} | {info.counter_name} | {info.date}")
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -69,7 +90,7 @@ if __name__ == "__main__":
   <TabItem value="nodejs" label="Node.js">
 
 ```javascript
-const { Config, CalendarContext, OAuth } = require('longbridge')
+const { CalendarCategory, CalendarContext, Config, OAuth } = require('longbridge')
 
 async function main() {
   const oauth = await OAuth.build('your-client-id', (_, url) => {
@@ -77,7 +98,7 @@ async function main() {
   })
   const config = Config.fromOAuth(oauth)
   const ctx = CalendarContext.new(config)
-  const resp = await ctx.split_calendar('AAPL.US')
+  const resp = await ctx.financeCalendar(CalendarCategory.Split, '2026-06-30', '2026-06-30', 'HK')
   console.log(resp)
 }
 main().catch(console.error)
@@ -95,7 +116,12 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              CalendarContext ctx = CalendarContext.create(config)) {
-            var resp = ctx.getSplitCalendar("AAPL.US").get();
+            FinanceCalendarOptions opts = new FinanceCalendarOptions();
+            opts.category = CalendarCategory.Split;
+            opts.start = "2026-06-30";
+            opts.end = "2026-06-30";
+            opts.market = "HK";
+            var resp = ctx.getFinanceCalendar(opts).get();
             System.out.println(resp);
         }
     }
@@ -107,14 +133,14 @@ class Main {
 
 ```rust
 use std::sync::Arc;
-use longbridge::{oauth::OAuthBuilder, calendar::CalendarContext, Config};
+use longbridge::{oauth::OAuthBuilder, calendar::{CalendarCategory, CalendarContext}, Config};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oauth = OAuthBuilder::new("your-client-id").build(|url| println!("Open: {url}")).await?;
     let config = Arc::new(Config::from_oauth(oauth));
     let ctx = CalendarContext::new(config);
-    let resp = ctx.split_calendar("AAPL.US").await?;
+    let resp = ctx.finance_calendar(CalendarCategory::Split, "2026-06-30", "2026-06-30", Some("HK".to_string())).await?;
     println!("{:?}", resp);
     Ok(())
 }
@@ -137,7 +163,7 @@ int main() {
             if (!res) return;
             Config config = Config::from_oauth(*res);
             CalendarContext ctx = CalendarContext::create(config);
-            ctx.split_calendar("AAPL.US", [](auto resp) {
+            ctx.finance_calendar(CalendarCategory::Split, "2026-06-30", "2026-06-30", "HK", [](auto resp) {
                 if (resp) std::cout << "OK" << std::endl;
             });
         });
@@ -156,9 +182,9 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/longbridge/openapi-go/calendar"
 	"github.com/longbridge/openapi-go/config"
 	"github.com/longbridge/openapi-go/oauth"
-	"github.com/longbridge/openapi-go/calendar"
 )
 
 func main() {
@@ -176,7 +202,8 @@ func main() {
 		log.Fatal(err)
 	}
 	defer c.Close()
-	resp, err := c.SplitCalendar(context.Background(), "AAPL.US")
+	market := "HK"
+	resp, err := c.FinanceCalendar(context.Background(), calendar.CalendarCategorySplit, "2026-06-30", "2026-06-30", &market)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -189,7 +216,6 @@ func main() {
 
 ## Response
 
-
 ### Response Example
 
 ```json
@@ -197,20 +223,20 @@ func main() {
   "code": 0,
   "message": "success",
   "data": {
-    "date": "2026-04-30",
+    "date": "2026-06-30",
     "list": [
       {
-        "date": "2026-04-30",
-        "count": 2228,
+        "date": "2026-06-30",
+        "count": 1,
         "infos": [
           {
             "id": "12345",
-            "symbol": "AAPL.US",
-            "market": "US",
-            "counter_name": "Apple Inc.",
+            "symbol": "0700.HK",
+            "market": "HK",
+            "counter_name": "Tencent Holdings",
             "event_type": "",
             "activity_type": "",
-            "date": "2026-05-14",
+            "date": "2026-06-30",
             "datetime": "",
             "content": "",
             "star": 0,
@@ -230,10 +256,10 @@ func main() {
 
 ### Response Status
 
-| Status | Description | Schema |
-| ------ | ----------- | ------ |
-| 200    | 成功     | [CalendarEventsResponse](#CalendarEventsResponse) |
-| 400    | 請求錯誤 | None   |
+| Status | Description | Schema                                            |
+| ------ | ----------- | ------------------------------------------------- |
+| 200    | 成功        | [CalendarEventsResponse](#CalendarEventsResponse) |
+| 400    | 請求錯誤    | None                                              |
 
 ## Schemas
 
@@ -241,40 +267,40 @@ func main() {
 
 <a id="CalendarEventsResponse"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 否 | 響應日期 |
-| list | object[] | 是 | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
+| Name | Type     | Required | Description                                                  |
+| ---- | -------- | -------- | ------------------------------------------------------------ |
+| date | string   | 否       | 響應日期                                                     |
+| list | object[] | 是       | 日曆日期分組列表，見 [CalendarDateGroup](#CalendarDateGroup) |
 
 ### CalendarDateGroup
 
 <a id="CalendarDateGroup"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| date | string | 是 | 日期 |
-| count | integer | 否 | 該日期的事件數量 |
-| infos | object[] | 是 | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
+| Name  | Type     | Required | Description                                              |
+| ----- | -------- | -------- | -------------------------------------------------------- |
+| date  | string   | 是       | 日期                                                     |
+| count | integer  | 否       | 該日期的事件數量                                         |
+| infos | object[] | 是       | 日曆事件列表，見 [CalendarEventInfo](#CalendarEventInfo) |
 
 ### CalendarEventInfo
 
 <a id="CalendarEventInfo"></a>
 
-| Name | Type | Required | Description |
-| ---- | ---- | -------- | ----------- |
-| id | string | 否 | 事件 ID |
-| symbol | string | 否 | 證券代碼 |
-| market | string | 否 | 市場 |
-| counter_name | string | 否 | 證券名稱 |
-| event_type | string | 否 | 事件類型 |
-| activity_type | string | 否 | 活動類型 |
-| date | string | 否 | 事件日期 |
-| datetime | string | 否 | 事件時間 |
-| date_type | string | 否 | 日期類型 |
-| content | string | 否 | 事件內容描述 |
-| currency | string | 否 | 貨幣 |
-| star | integer | 否 | 重要性（1-3 星） |
-| icon | string | 否 | 圖標鏈接 |
-| chart_uid | string | 否 | 圖表標識符 |
-| financial_market_time | string | 否 | 金融市場時間 |
-| data_kv | object[] | 否 | 鍵值數據對 |
+| Name                  | Type     | Required | Description      |
+| --------------------- | -------- | -------- | ---------------- |
+| id                    | string   | 否       | 事件 ID          |
+| symbol                | string   | 否       | 證券代碼         |
+| market                | string   | 否       | 市場             |
+| counter_name          | string   | 否       | 證券名稱         |
+| event_type            | string   | 否       | 事件類型         |
+| activity_type         | string   | 否       | 活動類型         |
+| date                  | string   | 否       | 事件日期         |
+| datetime              | string   | 否       | 事件時間         |
+| date_type             | string   | 否       | 日期類型         |
+| content               | string   | 否       | 事件內容描述     |
+| currency              | string   | 否       | 貨幣             |
+| star                  | integer  | 否       | 重要性（1-3 星） |
+| icon                  | string   | 否       | 圖標鏈接         |
+| chart_uid             | string   | 否       | 圖表標識符       |
+| financial_market_time | string   | 否       | 金融市場時間     |
+| data_kv               | object[] | 否       | 鍵值數據對       |


### PR DESCRIPTION
- Replace outdated per-category SDK calls (e.g. `dividend_calendar`) with the unified `finance_calendar` method across all 7 calendar types
- Add missing zh-CN / zh-HK translations for meeting_calendar and merge_calendar (4 new files)
- Add CliCommand blocks, Response Example, and Schemas sections to meeting/merge docs for parity with other calendar pages
- Fix misleading response examples: macro calendar no longer shows stock-specific data, split calendar response matches HK market request, earnings count corrected, dates unified to match request params


Related issue: #1109 