### PR TITLE
docs: add client_request_id and idempotency support to order submit API

### DIFF
--- a/docs/en/docs/trade/order/submit.md
+++ b/docs/en/docs/trade/order/submit.md
@@ -50,6 +50,24 @@ longbridge order sell TSLA.US 100 --price 260.00
 | limit_depth_level  | int32  | NO       | Specifies the bid/ask depth level. Value range is -5 ~ 0 ~ 5. <br/>Negative numbers indicate bid levels (e.g., -1 means best bid level 1),<br/>positive numbers indicate ask levels (e.g., 1 means best ask level 1).<br/>When set to 0, the `limit_offset` parameter takes effect.<br/>Valid for `TSLPAMT` / `TSLPPCT` orders. |
 | monitor_price      | string | NO       | Monitoring price. <br/>Monitoring starts only after reaching this price, updating the reference price.<br/>Valid for `TSLPAMT` / `TSLPPCT` orders.                                                                                                                                                                              |
 | trigger_count      | int32  | NO       | Number of triggers. Value range is 0 ~ 3.<br/>Specifies that within 1 minute, the order will only be placed after being triggered multiple times.<br/>Valid for `LIT` / `MIT` / `TSLPAMT` / `TSLPPCT` orders.                                                                                                                   |
+| client_request_id  | string | NO       | Idempotent request ID for preventing duplicate order submissions. The server caches this request ID for 10 minutes. If a request with the same ID is received within this period, it returns the same response without creating a duplicate order. Must be a unique identifier (e.g., UUID). |
+
+### Idempotency
+
+To ensure orders are not duplicated due to network retries or client failures, you can use the `client_request_id` parameter:
+
+- **Purpose**: Prevents duplicate order creation when the same request is retried
+- **Cache Duration**: 10 minutes (server-side)
+- **Format**: Any unique string per request (e.g., UUID, or a client-generated identifier)
+- **Behavior**: If the same `client_request_id` is received within 10 minutes, the server returns the cached response from the original request without creating a new order
+
+#### Idempotency Example
+
+```
+First request:  client_request_id="abc123-uuid-request" → Creates order with ID 12345
+Retry (same ID within 10 min): client_request_id="abc123-uuid-request" → Returns existing order ID 12345 (no duplicate)
+New request:    client_request_id="xyz789-uuid-request" → Creates new order with different ID
+```
 
 ### Request Example
 

--- a/docs/zh-CN/docs/trade/order/submit.md
+++ b/docs/zh-CN/docs/trade/order/submit.md
@@ -46,6 +46,24 @@ longbridge order sell TSLA.US 100 --price 260.00
 | limit_depth_level  | int32  | NO       | 指定买卖档位，取值范围为 -5 ～ 0 ～ 5，负数代表买盘档位（如 -1 表示买一），<br/>正数代表卖盘档位（如 1 表示卖一），为 0 时 limit_offset 参数生效<br/>`TSLPAMT` / `TSLPPCT` 订单有效 |
 | monitor_price      | string |  NO      | 监控价格，需要达到该价格才会开始监控，更新参考价<br/>`TSLPAMT` / `TSLPPCT` 订单有效 |
 | trigger_count      | int32  |  NO      | 触发次数，取值范围 0 ~ 3, 表示在 1 分钟内触发多次才会触发订单<br/>`LIT` / `MIT` / `TSLPAMT` / `TSLPPCT` 订单有效 |
+| client_request_id  | string | NO       | 幂等性请求 ID，用于防止重复下单。服务器会缓存该请求 ID 10 分钟。在此期间内如果收到相同 ID 的请求，将返回原始响应而不创建重复订单。必须是唯一标识符（如 UUID）。 |
+
+## 幂等性
+
+为了防止由于网络重试或客户端故障而导致订单重复，您可以使用 `client_request_id` 参数：
+
+- **用途**：防止相同请求重试时创建重复订单
+- **缓存时长**：10 分钟（服务器端）
+- **格式**：每个请求需要一个唯一字符串（如 UUID 或自定义标识符）
+- **行为**：如果在 10 分钟内收到相同的 `client_request_id`，服务器将返回原始请求的缓存响应，而不创建新订单
+
+#### 幂等性示例
+
+```
+首次请求：client_request_id="abc123-uuid-request" → 创建订单，ID 为 12345
+重试请求（10 分钟内，相同 ID）：client_request_id="abc123-uuid-request" → 返回现有订单 ID 12345（无重复）
+新请求：client_request_id="xyz789-uuid-request" → 创建新订单
+```
 
 ## Examples
 

--- a/docs/zh-HK/docs/trade/order/submit.md
+++ b/docs/zh-HK/docs/trade/order/submit.md
@@ -50,6 +50,24 @@ longbridge order sell TSLA.US 100 --price 260.00
 | limit_depth_level  | int32  | NO       | 指定買賣檔位，取值範圍為 -5 ～ 0 ～ 5，負數代表買盤檔位（例如 -1 表示買一），<br/>正數代表賣盤檔位（例如 1 表示賣一），當為 0 時 limit_offset 參數生效<br/>`TSLPAMT` / `TSLPPCT` 訂單有效 |
 | monitor_price      | string |  NO      | 監控價格，需要達到該價格才會開始監控，更新參考價<br/>`TSLPAMT` / `TSLPPCT` 訂單有效 |
 | trigger_count      | int32  |  NO      | 觸發次數，取值範圍 0 ~ 3，表示在 1 分鐘內觸發多次才會觸發訂單，<br/>`LIT` / `MIT` / `TSLPAMT` / `TSLPPCT` 訂單有效 |
+| client_request_id  | string | NO       | 冪等性請求 ID，用於防止重複下單。服務器會快取該請求 ID 10 分鐘。在此期間內如果收到相同 ID 的請求，將返回原始響應而不建立重複訂單。必須是唯一標識符（如 UUID）。 |
+
+### 冪等性
+
+為了防止由於網路重試或客戶端故障而導致訂單重複，您可以使用 `client_request_id` 參數：
+
+- **用途**：防止相同請求重試時建立重複訂單
+- **快取時長**：10 分鐘（服務器端）
+- **格式**：每個請求需要一個唯一字符串（如 UUID 或自定義標識符）
+- **行為**：如果在 10 分鐘內收到相同的 `client_request_id`，服務器將返回原始請求的快取響應，而不建立新訂單
+
+#### 冪等性示例
+
+```
+首次請求：client_request_id="abc123-uuid-request" → 建立訂單，ID 為 12345
+重試請求（10 分鐘內，相同 ID）：client_request_id="abc123-uuid-request" → 返回現有訂單 ID 12345（無重複）
+新請求：client_request_id="xyz789-uuid-request" → 建立新訂單
+```
 
 ### Request Example
 


### PR DESCRIPTION
- Add client_request_id parameter to prevent duplicate order submissions
- Document 10-minute server-side cache duration
- Include idempotency explanation and examples in all three language versions (en, zh-CN, zh-HK)
- Update parameter tables and add new Idempotency/冪等性 sections