### PR TITLE
docs: clarify client_request_id optional behavior and idempotency bypass

### DIFF
--- a/docs/en/docs/trade/order/submit.md
+++ b/docs/en/docs/trade/order/submit.md
@@ -69,6 +69,16 @@ Retry (same ID within 10 min): client_request_id="abc123-uuid-request" → Retur
 New request:    client_request_id="xyz789-uuid-request" → Creates new order with different ID
 ```
 
+#### When Omitting client_request_id
+
+If you do not provide `client_request_id` (or pass an empty value), the request will still succeed and create an order normally. However, **idempotency protection will be skipped**, meaning:
+
+- Each request (even identical ones) will create a separate order
+- Network retries or accidental duplicate requests may result in duplicate orders
+- No server-side caching of the request will be performed
+
+It is strongly recommended to always provide a unique `client_request_id` for critical order submissions to prevent unintended duplicates.
+
 ### Request Example
 
 <Tabs groupId="request-example">

--- a/docs/zh-CN/docs/trade/order/submit.md
+++ b/docs/zh-CN/docs/trade/order/submit.md
@@ -65,6 +65,16 @@ longbridge order sell TSLA.US 100 --price 260.00
 新请求：client_request_id="xyz789-uuid-request" → 创建新订单
 ```
 
+#### 不传 client_request_id 的情况
+
+如果不提供 `client_request_id`（或传空值），请求仍会正常成功并创建订单。但是**幂等拦截将被跳过**，这意味着：
+
+- 每个请求（即使内容完全相同）都会创建单独的订单
+- 网络重试或意外重复请求可能导致订单重复
+- 服务器不会对该请求进行缓存
+
+强烈建议在关键下单操作中始终提供唯一的 `client_request_id`，以防止意外的重复订单。
+
 ## Examples
 
 为了方便理解，我们下面以 Python 作为示例，介绍如何实现一些场景的下单操作。

--- a/docs/zh-HK/docs/trade/order/submit.md
+++ b/docs/zh-HK/docs/trade/order/submit.md
@@ -69,6 +69,16 @@ longbridge order sell TSLA.US 100 --price 260.00
 新請求：client_request_id="xyz789-uuid-request" → 建立新訂單
 ```
 
+#### 不傳 client_request_id 的情況
+
+如果不提供 `client_request_id`（或傳空值），請求仍會正常成功並建立訂單。但是**冪等攔截將被跳過**，這意味著：
+
+- 每個請求（即使內容完全相同）都會建立單獨的訂單
+- 網路重試或意外重複請求可能導致訂單重複
+- 服務器不會對該請求進行快取
+
+強烈建議在關鍵下單操作中始終提供唯一的 `client_request_id`，以防止意外的重複訂單。
+
 ### Request Example
 
 <Tabs groupId="request-example">


### PR DESCRIPTION
- Clarify that client_request_id is optional and omitting it skips protection