### PR TITLE
Add brand assets documentation page

### DIFF
--- a/docs/.vitepress/theme/components/AppFooter.vue
+++ b/docs/.vitepress/theme/components/AppFooter.vue
@@ -75,6 +75,9 @@ const year = new Date().getFullYear()
             <a :href="localePath('/docs/getting-started')">{{ t('footer.gettingStarted') }}</a>
           </li>
           <li><a :href="localePath('/docs')">Documentation</a></li>
+          <li>
+            <a :href="localePath('/docs/assets')">{{ t('footer.assets') }}</a>
+          </li>
           <li><a :href="localePath('/docs/quote/pull/quote')">Quote API</a></li>
           <li><a :href="localePath('/docs/trade/order/submit')">Trade API</a></li>
           <li>

--- a/docs/.vitepress/theme/components/HomePage/Footer.vue
+++ b/docs/.vitepress/theme/components/HomePage/Footer.vue
@@ -42,7 +42,7 @@ const { t, locale } = useI18n()
 const isCN = computed(() => !isServer() && window.location.host.endsWith('.cn'))
 
 const sgBaseUrl = computed(() =>
-  locale.value === 'en' ? 'https://longbridge.com/sg' : 'https://longbridge.com/sg/zh-CN',
+  locale.value === 'en' ? 'https://longbridge.com/sg' : 'https://longbridge.com/sg/zh-CN'
 )
 
 // 备案文案
@@ -63,13 +63,14 @@ const leftLinks = computed(() => [
   },
 ])
 
-const rightLinks = [
+const rightLinks = computed(() => [
   { href: '/sdk', label: 'SDK' },
   { href: '/docs/mcp', label: 'MCP' },
   { href: '/docs/cli', label: 'CLI' },
   { href: '/docs/llm', label: 'LLM' },
+  { href: '/docs/assets', label: t('footer.assets') },
   { href: 'https://github.com/longbridge/developers/issues', label: 'Feedback' },
-]
+])
 </script>
 
 <style scoped>

--- a/docs/.vitepress/theme/components/NewHomePage/Footer.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/Footer.vue
@@ -44,7 +44,7 @@ const { t, locale } = useI18n()
 const isCN = computed(() => !isServer() && window.location.host.endsWith('.cn'))
 
 const sgBaseUrl = computed(() =>
-  locale.value === 'en' ? 'https://longbridge.com/sg' : 'https://longbridge.com/sg/zh-CN',
+  locale.value === 'en' ? 'https://longbridge.com/sg' : 'https://longbridge.com/sg/zh-CN'
 )
 
 const beianText = computed(() => {
@@ -64,13 +64,14 @@ const leftLinks = computed(() => [
   },
 ])
 
-const rightLinks = [
+const rightLinks = computed(() => [
   { href: '/sdk', label: 'SDK' },
   { href: '/docs/mcp', label: 'MCP' },
   { href: '/docs/cli', label: 'CLI' },
   { href: '/docs/llm', label: 'LLM' },
+  { href: '/docs/assets', label: t('footer.assets') },
   { href: 'https://github.com/longbridge/developers/issues', label: 'Feedback' },
-]
+])
 </script>
 
 <style scoped>

--- a/docs/.vitepress/theme/layouts/Layout.vue
+++ b/docs/.vitepress/theme/layouts/Layout.vue
@@ -3,8 +3,10 @@ import MockLoginPanel from '../components/MockLoginPanel.vue'
 import Breadcrumb from '../components/Breadcrumb/index.vue'
 import Layout from './LayoutInner.vue'
 import { useI18nSync, useHighlighter, useLLMMarkdownLink, useLbDarkSync } from '../composables'
+import { useData } from 'vitepress'
 
 const isDev = import.meta.env.DEV
+const { frontmatter } = useData()
 
 useI18nSync()
 useHighlighter()
@@ -20,21 +22,37 @@ const { llmMarkdownLink } = useLLMMarkdownLink()
     </template>
 
     <template #doc-top>
-      <div class="-mt-4">
+      <div v-if="frontmatter.breadcrumb !== false" class="-mt-4">
         <Breadcrumb />
       </div>
     </template>
 
     <template #doc-footer-before>
       <a v-if="llmMarkdownLink" :href="llmMarkdownLink" target="_blank" class="llms-text-link" title="LLMs Text">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"/><path d="M14 2v5a1 1 0 0 0 1 1h5"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>Markdown
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          style="margin-right: 6px">
+          <path
+            d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+          <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+          <path d="M10 9H8" />
+          <path d="M16 13H8" />
+          <path d="M16 17H8" /></svg
+        >Markdown
       </a>
     </template>
   </Layout>
 </template>
 
 <style>
-
 .VPSwitchAppearance {
   width: 22px !important;
 }

--- a/docs/.vitepress/theme/locales/en.json
+++ b/docs/.vitepress/theme/locales/en.json
@@ -81,6 +81,7 @@
   "footer.company": "Company",
   "footer.legal": "Legal",
   "footer.gettingStarted": "Getting Started",
+  "footer.assets": "Assets",
   "footer.changelog": "Changelog",
   "footer.feedback": "Feedback",
   "footer.terms": "Terms of Service",

--- a/docs/.vitepress/theme/locales/zh-CN.json
+++ b/docs/.vitepress/theme/locales/zh-CN.json
@@ -81,6 +81,7 @@
   "footer.company": "公司",
   "footer.legal": "法律",
   "footer.gettingStarted": "快速入门",
+  "footer.assets": "图片资源",
   "footer.changelog": "更新日志",
   "footer.feedback": "意见反馈",
   "footer.terms": "服务条款",

--- a/docs/.vitepress/theme/locales/zh-HK.json
+++ b/docs/.vitepress/theme/locales/zh-HK.json
@@ -81,6 +81,7 @@
   "footer.company": "公司",
   "footer.legal": "法律",
   "footer.gettingStarted": "快速入門",
+  "footer.assets": "圖片資源",
   "footer.changelog": "更新日誌",
   "footer.feedback": "意見反饋",
   "footer.terms": "服務條款",

--- a/docs/.vitepress/theme/style/index.css
+++ b/docs/.vitepress/theme/style/index.css
@@ -65,14 +65,14 @@ html:root {
 /* Dark mode: align VitePress doc background with LB design system */
 html.dark {
   --vp-c-brand-1: var(--brand-80);
-  --vp-c-bg: #0A0E19;
-  --vp-c-bg-alt: #161A26;
-  --vp-c-bg-soft: #13182A;
-  --vp-c-bg-mute: #161A26;
+  --vp-c-bg: #0a0e19;
+  --vp-c-bg-alt: #161a26;
+  --vp-c-bg-soft: #13182a;
+  --vp-c-bg-mute: #161a26;
 }
 
 html.dark .vp-doc th {
-  background-color: #0E1120;
+  background-color: #0e1120;
 }
 
 /* AppNav is position:fixed; suppress VitePress padding-top only for sidebar pages (which manage their own layout) */
@@ -245,4 +245,125 @@ html.dark .vp-doc th {
 .vp-cli-action:hover {
   color: var(--vp-c-text-1);
   background-color: var(--vp-c-default-soft);
+}
+
+/* Brand assets Markdown HTML layout */
+.vp-doc .brand-assets-markdown {
+  display: grid;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.vp-doc .brand-asset-markdown-card {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 18px 22px;
+  align-items: start;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  padding: 18px;
+}
+
+.vp-doc .brand-asset-markdown-preview {
+  display: flex;
+  min-height: 124px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 16px;
+  border-radius: 8px;
+}
+
+.vp-doc .brand-asset-markdown-preview.is-light {
+  background:
+    linear-gradient(45deg, rgba(130, 136, 141, 0.12) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(130, 136, 141, 0.12) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(130, 136, 141, 0.12) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(130, 136, 141, 0.12) 75%), var(--vp-c-bg);
+  background-position:
+    0 0,
+    0 8px,
+    8px -8px,
+    -8px 0;
+  background-size: 16px 16px;
+}
+
+.vp-doc .brand-asset-markdown-preview.is-dark {
+  background: #0a0e19;
+}
+
+.vp-doc .brand-asset-markdown-preview.is-icon {
+  background: linear-gradient(135deg, var(--vp-c-bg-soft), var(--vp-c-bg-alt));
+}
+
+.vp-doc .brand-asset-markdown-preview img {
+  display: block;
+  max-width: min(100%, 320px);
+  max-height: 84px;
+  object-fit: contain;
+}
+
+.vp-doc .brand-asset-markdown-preview.is-icon img {
+  max-width: 72px;
+  max-height: 72px;
+}
+
+.vp-doc .brand-asset-markdown-body {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  padding-top: 2px;
+}
+
+.vp-doc .brand-asset-markdown-body h2 {
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  font-size: 20px;
+  line-height: 1.35;
+}
+
+.vp-doc .brand-asset-markdown-body p {
+  margin: 0 !important;
+  line-height: 1.55;
+  color: var(--vp-c-text-2);
+}
+
+.vp-doc .brand-asset-markdown-body dl {
+  display: grid;
+  gap: 2px;
+  margin: 0 !important;
+}
+
+.vp-doc .brand-asset-markdown-body dt,
+.vp-doc .brand-asset-markdown-url span {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--vp-c-text-3);
+  text-transform: uppercase;
+}
+
+.vp-doc .brand-asset-markdown-body dd {
+  min-width: 0;
+  margin: 0 !important;
+  color: var(--vp-c-text-1);
+}
+
+.vp-doc .brand-asset-markdown-url {
+  display: grid;
+  grid-column: 1 / -1;
+  gap: 4px;
+  min-width: 0;
+}
+
+.vp-doc .brand-asset-markdown-url a {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+@media (max-width: 760px) {
+  .vp-doc .brand-asset-markdown-card {
+    grid-template-columns: 1fr;
+  }
 }

--- a/docs/en/docs/assets/_category_.json
+++ b/docs/en/docs/assets/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 9,
+  "label": "Brand Assets",
+  "icon": "book",
+  "indexLink": "/assets/"
+}

--- a/docs/en/docs/assets/index.md
+++ b/docs/en/docs/assets/index.md
@@ -1,0 +1,109 @@
+---
+title: 'Brand Assets'
+id: docs_assets
+description: Official Longbridge brand image resources and CDN URLs.
+sidebar: false
+aside: false
+editLink: false
+prev: false
+next: false
+breadcrumb: false
+---
+
+# Longbridge Image Resources
+
+Use these official CDN URLs when referencing Longbridge Developers and Longbridge brand imagery.
+
+> These resources are hosted on the Longbridge CDN. Reference the URLs directly instead of adding image files to this repository.
+
+<div class="brand-assets-markdown">
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-icon">
+      <img src="https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg" alt="Icon" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Icon</h2>
+      <p>Square icon for avatar-style placements, such as GitHub Avatar or Twitter Avatar.</p>
+      <dl>
+        <dt>Format</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg">https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-dark">
+      <img src="https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png" alt="Longbridge Developers Logo dark" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Longbridge Developers Logo (dark)</h2>
+      <p>Longbridge Developers logo, dark variant.</p>
+      <dl>
+        <dt>Format</dt>
+        <dd>PNG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png">https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-light">
+      <img src="https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png" alt="Longbridge Developers Logo light" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Longbridge Developers Logo (light)</h2>
+      <p>Longbridge Developers logo, light variant.</p>
+      <dl>
+        <dt>Format</dt>
+        <dd>PNG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png">https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-light">
+      <img src="https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg" alt="Logo light" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Logo (light)</h2>
+      <p>Longbridge logo, light variant.</p>
+      <dl>
+        <dt>Format</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg">https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-dark">
+      <img src="https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg" alt="Logo dark" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Logo (dark)</h2>
+      <p>Longbridge logo, dark variant.</p>
+      <dl>
+        <dt>Format</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg">https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg</a>
+    </div>
+  </section>
+</div>

--- a/docs/zh-CN/docs/assets/_category_.json
+++ b/docs/zh-CN/docs/assets/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 9,
+  "label": "图片资源",
+  "icon": "book",
+  "indexLink": "/assets/"
+}

--- a/docs/zh-CN/docs/assets/index.md
+++ b/docs/zh-CN/docs/assets/index.md
@@ -1,0 +1,109 @@
+---
+title: '图片资源'
+id: docs_assets
+description: Longbridge 官方品牌图片资源和 CDN 地址。
+sidebar: false
+aside: false
+editLink: false
+prev: false
+next: false
+breadcrumb: false
+---
+
+# Longbridge 图片资源
+
+引用 Longbridge Developers 和 Longbridge 品牌图片时，请使用以下官方 CDN 地址。
+
+> 这些资源托管在 Longbridge CDN。请直接引用 URL，不要把图片文件加入仓库。
+
+<div class="brand-assets-markdown">
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-icon">
+      <img src="https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg" alt="Icon" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Icon</h2>
+      <p>用于需要正方形 Icon 的场景，例如 GitHub Avatar、Twitter Avatar 等。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg">https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-dark">
+      <img src="https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png" alt="Longbridge Developers Logo dark" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Longbridge Developers Logo (dark)</h2>
+      <p>Longbridge Developers 深色版本标志。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>PNG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png">https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-light">
+      <img src="https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png" alt="Longbridge Developers Logo light" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Longbridge Developers Logo (light)</h2>
+      <p>Longbridge Developers 浅色版本标志。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>PNG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png">https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-light">
+      <img src="https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg" alt="Logo light" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Logo (light)</h2>
+      <p>Longbridge 浅色版本标志。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg">https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-dark">
+      <img src="https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg" alt="Logo dark" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Logo (dark)</h2>
+      <p>Longbridge 深色版本标志。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg">https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg</a>
+    </div>
+  </section>
+</div>

--- a/docs/zh-HK/docs/assets/_category_.json
+++ b/docs/zh-HK/docs/assets/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 9,
+  "label": "圖片資源",
+  "icon": "book",
+  "indexLink": "/assets/"
+}

--- a/docs/zh-HK/docs/assets/index.md
+++ b/docs/zh-HK/docs/assets/index.md
@@ -1,0 +1,109 @@
+---
+title: '圖片資源'
+id: docs_assets
+description: Longbridge 官方品牌圖片資源和 CDN 地址。
+sidebar: false
+aside: false
+editLink: false
+prev: false
+next: false
+breadcrumb: false
+---
+
+# Longbridge 圖片資源
+
+引用 Longbridge Developers 和 Longbridge 品牌圖片時，請使用以下官方 CDN 地址。
+
+> 這些資源託管在 Longbridge CDN。請直接引用 URL，不要把圖片文件加入倉庫。
+
+<div class="brand-assets-markdown">
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-icon">
+      <img src="https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg" alt="Icon" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Icon</h2>
+      <p>用於需要正方形 Icon 的場景，例如 GitHub Avatar、Twitter Avatar 等。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg">https://assets.lbkrs.com/uploads/2e476c46-8bb9-4689-a800-54877351520e/app-icon.svg</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-dark">
+      <img src="https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png" alt="Longbridge Developers Logo dark" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Longbridge Developers Logo (dark)</h2>
+      <p>Longbridge Developers 深色版本標誌。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>PNG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png">https://assets.lbkrs.com/uploads/37a18fa4-46a4-408c-a36a-560004eb3cfb/longbridge-developers-dark.png</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-light">
+      <img src="https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png" alt="Longbridge Developers Logo light" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Longbridge Developers Logo (light)</h2>
+      <p>Longbridge Developers 淺色版本標誌。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>PNG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png">https://assets.lbkrs.com/uploads/e76f6d93-80f8-4f9b-8b8d-2c86f0c94a78/longbridge-developers-light.png</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-light">
+      <img src="https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg" alt="Logo light" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Logo (light)</h2>
+      <p>Longbridge 淺色版本標誌。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg">https://assets.lbkrs.com/uploads/bf1df347-6ee7-4f6d-b716-171c74e24521/logo-light.svg</a>
+    </div>
+  </section>
+
+  <section class="brand-asset-markdown-card">
+    <figure class="brand-asset-markdown-preview is-dark">
+      <img src="https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg" alt="Logo dark" />
+    </figure>
+    <div class="brand-asset-markdown-body">
+      <h2>Logo (dark)</h2>
+      <p>Longbridge 深色版本標誌。</p>
+      <dl>
+        <dt>格式</dt>
+        <dd>SVG</dd>
+      </dl>
+    </div>
+    <div class="brand-asset-markdown-url">
+      <span>URL</span>
+      <a href="https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg">https://assets.lbkrs.com/uploads/1e1dcd32-a8a5-401f-a01c-aabec0cf9ff9/logo-dark.svg</a>
+    </div>
+  </section>
+</div>

--- a/scripts/copy-routes.ts
+++ b/scripts/copy-routes.ts
@@ -14,7 +14,15 @@ import path from 'path'
 const distDir = path.resolve('docs/.vitepress/dist')
 
 // Each entry: copy `dir/index.ext` → `dir.ext` (so both paths exist)
-const routes = ['skill/install', 'docs/cli', 'zh-CN/docs/cli', 'zh-HK/docs/cli']
+const routes = [
+  'skill/install',
+  'docs/cli',
+  'zh-CN/docs/cli',
+  'zh-HK/docs/cli',
+  'docs/assets',
+  'zh-CN/docs/assets',
+  'zh-HK/docs/assets',
+]
 
 const exts = ['.html', '.md']
 


### PR DESCRIPTION
Summary
- Add localized /docs/assets pages listing Longbridge brand image resources as Markdown/HTML for AI-readable access.
- Link the assets page from footer variants and add localized footer labels.
- Allow breadcrumb suppression via frontmatter and copy assets markdown routes after build.

Test Plan
- npx prettier -c scripts/copy-routes.ts docs/.vitepress/theme/layouts/Layout.vue docs/.vitepress/theme/style/index.css docs/.vitepress/theme/components/AppFooter.vue docs/.vitepress/theme/components/HomePage/Footer.vue docs/.vitepress/theme/components/NewHomePage/Footer.vue docs/en/docs/assets/index.md docs/zh-CN/docs/assets/index.md docs/zh-HK/docs/assets/index.md docs/en/docs/assets/_category_.json docs/zh-CN/docs/assets/_category_.json docs/zh-HK/docs/assets/_category_.json
- npx tsc --noEmit -p docs/tsconfig.json
- git diff --check
- JSON parse check for locale files and assets category files

Note
- Did not run build because repository instructions prohibit AI sessions from running build commands.