### PR TITLE
docs: add Content API overview pages and fix homepage capability card links

### DIFF
--- a/docs/.vitepress/theme/components/NewHomePage/index.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/index.vue
@@ -70,7 +70,10 @@ const LOCALE = {
       eyebrow: 'Longbridge CLI',
       title: 'AI-native command-line tool, covering every OpenAPI.',
       feats: [
-        ['130+ commands', '<a href="https://longbridge.com/markets">Market data</a>, trading, fundamentals — all in your shell.'],
+        [
+          '130+ commands',
+          '<a href="https://longbridge.com/markets">Market data</a>, trading, fundamentals — all in your shell.',
+        ],
         ['--format json output', "Pipe into jq, awk, or any AI agent's tool channel."],
         ['Multi-period candlesticks', 'Daily, hourly, 15-min, 5-min, 1-min — all from one flag.'],
         ['Portfolio P&L view', 'Position breakdown with allocation drill-down.'],
@@ -324,7 +327,10 @@ const LOCALE = {
           body: '无额外 API 费用。用真实市场数据进行模拟交易，无需证券账户。',
           strong: '零 API 费用',
         },
-        { h: '实时推送', body: 'WebSocket 推送<a href="https://longbridge.com/markets">报价</a>、买卖盘深度、成交及订单状态，延迟 &lt; 60 ms。' },
+        {
+          h: '实时推送',
+          body: 'WebSocket 推送<a href="https://longbridge.com/markets">报价</a>、买卖盘深度、成交及订单状态，延迟 &lt; 60 ms。',
+        },
         { h: 'OAuth 2.0 + 异步', body: '自动令牌管理，支持现代 async/await 模式及内置限速控制。' },
       ],
       cta: 'SDK 文档',
@@ -488,7 +494,10 @@ const LOCALE = {
           body: '無額外 API 費用。用真實市場數據進行模擬交易，無需證券帳戶。',
           strong: '零 API 費用',
         },
-        { h: '即時推送', body: 'WebSocket 推送<a href="https://longbridge.com/markets">報價</a>、買賣盤深度、成交及訂單狀態，延遲 &lt; 60 ms。' },
+        {
+          h: '即時推送',
+          body: 'WebSocket 推送<a href="https://longbridge.com/markets">報價</a>、買賣盤深度、成交及訂單狀態，延遲 &lt; 60 ms。',
+        },
         { h: 'OAuth 2.0 + 非同步', body: '自動令牌管理，支援現代 async/await 模式及內建限速控制。' },
       ],
       cta: 'SDK 文件',
@@ -1205,6 +1214,7 @@ const API_CAPS = [
   {
     icon: 'chart',
     color: 'var(--lb-status-neutral)',
+    link: '/docs/quote/overview',
     title: 'Market Data',
     count: '30+',
     desc: 'Real-time quotes, order depth, candlestick, intraday, capital flow, and push subscriptions',
@@ -1220,6 +1230,7 @@ const API_CAPS = [
   {
     icon: 'shield',
     color: 'var(--lb-brand)',
+    link: '/docs/trade/trade-overview',
     title: 'Trading & Orders',
     count: '14+',
     desc: 'Submit, replace, and withdraw orders. Track positions, balance, and execution history',
@@ -1228,6 +1239,7 @@ const API_CAPS = [
   {
     icon: 'bolt',
     color: 'var(--lb-ai-mention)',
+    link: '/docs/cli/derivatives/option',
     title: 'Derivatives',
     count: '8+',
     desc: 'Full option chains with Greeks, warrants listing, and real-time derivative quotes',
@@ -1236,6 +1248,7 @@ const API_CAPS = [
   {
     icon: 'book',
     color: 'var(--lb-chart-purple)',
+    link: '/docs/cli/fundamentals/financial-report',
     title: 'Financial Research',
     count: '7+',
     desc: 'Financial statements, valuation metrics, dividend history, EPS forecasts, analyst ratings',
@@ -1244,6 +1257,7 @@ const API_CAPS = [
   {
     icon: 'globe',
     color: 'var(--lb-status-alert)',
+    link: '/docs/content/overview',
     title: 'Content & News',
     count: '8+',
     desc: 'Real-time news feeds, community discussions, topics, and engagement metrics',
@@ -1773,9 +1787,7 @@ const GETSTARTED = [
             <span style="margin-left: 8px; font-size: 11.5px; color: var(--lb-fg-3)">~/projects/quant — claude</span>
             <button
               class="code-copy"
-              @click="
-                copyToClipboard('claude mcp add --transport http longbridge \\\n  https://mcp.longbridge.com')
-              ">
+              @click="copyToClipboard('claude mcp add --transport http longbridge \\\n  https://mcp.longbridge.com')">
               <svg
                 width="13"
                 height="13"
@@ -1846,7 +1858,7 @@ const GETSTARTED = [
           <h2 class="h-section" style="margin-top: 16px">{{ content.apiCaps.title }}</h2>
         </div>
         <div class="api-caps-grid">
-          <a v-for="c in apiCaps" :key="c.title" :href="localePath('/api')" class="api-cap-card">
+          <a v-for="c in apiCaps" :key="c.title" :href="localePath(c.link)" class="api-cap-card">
             <div class="api-cap-head">
               <div
                 class="api-cap-icon"

--- a/docs/en/docs/content/overview.md
+++ b/docs/en/docs/content/overview.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 0
+id: content_overview
+title: Overview
+slug: overview
+---
+
+# Content API Overview
+
+Content APIs provide security news, community topic discussions, and sharelist management. All APIs are accessed via HTTP requests, or through the [SDK](https://open.longbridge.com/sdk).
+
+<table>
+    <thead>
+    <tr>
+        <td>Type</td>
+        <td>Introduction</td>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td rowspan="1">News</td>
+        <td><a href="./news/news">Security News</a></td>
+    </tr>
+    <tr>
+        <td rowspan="6">Topics</td>
+        <td><a href="./topics/topics">Topics by Symbol</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/my-topics">My Topics</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/create-topic">Create Topic</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/topic-detail">Topic Detail</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/topic-replies">Topic Replies</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/create-topic-reply">Create Topic Reply</a></td>
+    </tr>
+    <tr>
+        <td rowspan="9">Sharelist</td>
+        <td><a href="./sharelist/list-sharelist">List Sharelists</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/create-sharelist">Create Sharelist</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/update-sharelist">Update Sharelist</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/delete-sharelist">Delete Sharelist</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/sharelist-detail">Sharelist Detail</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/popular-sharelist">Popular Sharelists</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/add-securities">Add Securities to Sharelist</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/remove-securities">Remove Securities from Sharelist</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/sort-securities">Sort Securities in Sharelist</a></td>
+    </tr>
+    </tbody>
+</table>

--- a/docs/zh-CN/docs/content/overview.md
+++ b/docs/zh-CN/docs/content/overview.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 0
+id: content_overview
+sidebar_label: 概览
+title: 概览
+slug: overview
+---
+
+# 资讯与社区接口概览
+
+资讯与社区接口提供个股资讯、社区讨论和股单管理能力。所有接口均通过 HTTP 请求访问，也可以使用 [SDK](https://open.longbridge.com/sdk) 调用。
+
+<table>
+    <thead>
+    <tr>
+        <td>类型</td>
+        <td>介绍</td>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td rowspan="1">资讯</td>
+        <td><a href="./news/news">个股资讯</a></td>
+    </tr>
+    <tr>
+        <td rowspan="6">讨论</td>
+        <td><a href="./topics/topics">标的社区讨论</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/my-topics">我的讨论</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/create-topic">创建讨论</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/topic-detail">讨论详情</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/topic-replies">讨论回复</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/create-topic-reply">创建讨论回复</a></td>
+    </tr>
+    <tr>
+        <td rowspan="9">股单</td>
+        <td><a href="./sharelist/list-sharelist">股单列表</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/create-sharelist">创建股单</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/update-sharelist">更新股单</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/delete-sharelist">删除股单</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/sharelist-detail">股单详情</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/popular-sharelist">热门股单</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/add-securities">添加标的到股单</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/remove-securities">从股单移除标的</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/sort-securities">股单标的排序</a></td>
+    </tr>
+    </tbody>
+</table>

--- a/docs/zh-HK/docs/content/overview.md
+++ b/docs/zh-HK/docs/content/overview.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 0
+id: content_overview
+sidebar_label: 概覽
+title: 概覽
+slug: overview
+---
+
+# 資訊與社區接口概覽
+
+資訊與社區接口提供個股資訊、社區討論和股單管理能力。所有接口均通過 HTTP 請求訪問，也可以使用 [SDK](https://open.longbridge.com/sdk) 調用。
+
+<table>
+    <thead>
+    <tr>
+        <td>類型</td>
+        <td>介紹</td>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td rowspan="1">資訊</td>
+        <td><a href="./news/news">個股資訊</a></td>
+    </tr>
+    <tr>
+        <td rowspan="6">討論</td>
+        <td><a href="./topics/topics">標的社區討論</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/my-topics">我的討論</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/create-topic">創建討論</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/topic-detail">討論詳情</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/topic-replies">討論回覆</a></td>
+    </tr>
+    <tr>
+        <td><a href="./topics/create-topic-reply">創建討論回覆</a></td>
+    </tr>
+    <tr>
+        <td rowspan="9">股單</td>
+        <td><a href="./sharelist/list-sharelist">股單列表</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/create-sharelist">創建股單</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/update-sharelist">更新股單</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/delete-sharelist">刪除股單</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/sharelist-detail">股單詳情</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/popular-sharelist">熱門股單</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/add-securities">新增標的到股單</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/remove-securities">從股單移除標的</a></td>
+    </tr>
+    <tr>
+        <td><a href="./sharelist/sort-securities">股單標的排序</a></td>
+    </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
## Merge Verdict

**[APPROVE]** — Docs-only change: adds Content API overview pages (3 locales) and fixes homepage API capability card links; all link targets verified against production.

> 4 files · +237 / -7 · `NewHomePage` `docs/content`

---

## Summary

- Homepage "API Capabilities" cards previously all linked to `/api`, which returns 404 in production — each of the 5 cards now links to its own capability page via a new `link` field on `API_CAPS`.
- Added `overview.md` for the Content module (News & Contents) in all three locales (`en`, `zh-CN`, `zh-HK`), following the structure of `quote/overview.md` / `trade/overview.md`: a categorized table (News ×1 / Topics ×6 / Sharelist ×9) linking to all 16 endpoint pages.
- Content & News card now points to the new `/docs/content/overview` page shipped in the same PR.

---

## Risk Analysis

| Risk | Level | Mitigation |
| ------ | ------ | ------------ |
| Broken link targets | ✅ | All 5 card URLs curl-verified: `/docs/quote/overview`, `/docs/trade/trade-overview`, `/docs/cli/derivatives/option`, `/docs/cli/fundamentals/financial-report` return 200 in production; `/docs/content/overview` is added by this PR |
| Overview link/title drift | ✅ | All 16 table links use the exact `slug` frontmatter of target pages; titles match target page `title` verbatim in each locale |
| Sidebar ordering | 🟢 | `sidebar_position: 0` sorts the overview before News(1)/Topics(2)/Sharelist(3), same pattern as the quote module |

---

## Design Decisions

- **Per-card links instead of a single `/docs/api` link**: matches user intent for the homepage capability grid; each card lands on its capability's most relevant page.
- **No Protobuf/WebSocket access sections in the Content overview**: Content APIs are plain HTTP REST, so the quote overview's private-protocol sections were intentionally not copied; a one-line HTTP + SDK note is kept instead.

---

## Code Concerns

1. **[信息]** Unused component with a stale broken link (`docs/.vitepress/theme/components/NewHomePage/CapSection.vue:64`)
   `CapSection.vue` is referenced by no file (dead code) and contains `/docs/trade/overview`, a live 404 — pre-existing and outside this diff; consider deleting the component or fixing its links in a follow-up.
   ——作者回复：Will be removed in a separate follow-up PR.

---

## Verification Status

✅ Link targets curl-verified against production · ✅ Slugs/titles cross-checked against target page frontmatter · 📋 To verify: homepage card navigation in local dev (`bun run dev`), including `/zh-CN` locale prefix handling
