### PR TITLE
docs: Add v0.26.0 CLI release notes

### DIFF
--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -7,6 +7,16 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.26.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.26.0)
+
+- **New TUI settings modal (`Ctrl+,`)** — first setting is up/down colors (red-up vs green-up); applied instantly and remembered across restarts in `~/.longbridge/terminal.json`
+- **Context-aware shortcut hints and mouse scrolling in the TUI** — the top bar now lists only the keys available on the current screen, and the scroll wheel moves the selection in the watchlist / orders / news / portfolio lists
+- **Refreshed TUI visuals** — rounded borders on panels and modals, bold titles and table headers, and a stacked asset-distribution bar on the Portfolio screen; all drawn in the terminal's own palette
+- **Access point no longer gets stuck on China Mainland** — the region is now decided by the country geotest reports rather than by whether it merely responds, and is re-checked every 6 hours, so a client that has left China Mainland stops being routed to `longbridge.cn`. `check` re-detects on every run, measures both access points and switches to whichever is decisively better; a connection failure against `.cn` now explains how to override the region
+- **Fix: `ipo calendar` returned no data** — the upstream aggregation endpoint began returning an empty summary for every account; the command is rebuilt on the data sources that still work
+- **Fix: clearer error for US option quotes** — `option quote` now explains that the "OPRA US Options" OpenAPI market-data permission is required and links to pricing, instead of surfacing a bare `301604`
+- **Fix: `ipo detail` degrades gracefully** — timeline, eligibility and holdings are treated as optional enrichment, so the core profile still prints when an auxiliary endpoint is unavailable (`null` in JSON, warnings under `-v`)
+
 ### [v0.25.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.25.0)
 
 - **US data-center support** — `auth login` (device flow and `--auth-code`) can now authorize US accounts, and every authenticated request routes to the data center matching the token; `auth status` shows the active DC region

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -7,6 +7,16 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.26.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.26.0)
+
+- **新增 TUI 设置弹窗（`Ctrl+,`）** — 首个设置项为涨跌颜色（红涨 / 绿涨），即时生效并写入 `~/.longbridge/terminal.json`，重启后保留
+- **TUI 快捷键提示随页面变化，支持鼠标滚轮** — 顶栏只列出当前页面可用的快捷键；滚轮可在自选 / 订单 / 新闻 / 持仓列表中移动选中项
+- **TUI 视觉升级** — 面板与弹窗改为圆角边框，标题与表头加粗，持仓页新增堆叠式资产分布条；全部沿用终端自身配色
+- **接入点不再卡在中国大陆** — 区域判定改为读取 geotest 返回的国家，而非仅判断其是否可达，并每 6 小时重新检测，离开中国大陆后不会继续被路由到 `longbridge.cn`。`check` 每次运行都会重新检测，实测两个接入点并切换到明显更优的一侧；`.cn` 连接失败时会提示如何手动指定区域
+- **修复：`ipo calendar` 无数据** — 上游聚合接口开始对所有账户返回空摘要，该命令已改用仍然可用的数据源重建
+- **修复：美股期权行情报错更清晰** — `option quote` 现会说明需要「OPRA US Options」OpenAPI 行情权限并附上订阅页链接，不再只抛出 `301604`
+- **修复：`ipo detail` 局部降级** — 时间轴、申购资格与持股数据视为可选补充信息，辅助接口不可用时仍会输出核心资料（JSON 中为 `null`，`-v` 下给出告警）
+
 ### [v0.25.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.25.0)
 
 - **支持美国数据中心** — `auth login`（设备码流程与 `--auth-code`）支持美国账户授权，所有请求会按 token 自动路由到对应数据中心；`auth status` 展示当前 DC 区域

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -7,6 +7,16 @@ sidebar_icon: newspaper
 
 # Release Notes
 
+### [v0.26.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.26.0)
+
+- **新增 TUI 設定彈窗（`Ctrl+,`）** — 首個設定項為漲跌顏色（紅漲 / 綠漲），即時生效並寫入 `~/.longbridge/terminal.json`，重啟後保留
+- **TUI 快捷鍵提示隨頁面變化，支持滑鼠滾輪** — 頂欄只列出當前頁面可用的快捷鍵；滾輪可在自選 / 訂單 / 新聞 / 持倉列表中移動選中項
+- **TUI 視覺升級** — 面板與彈窗改為圓角邊框，標題與表頭加粗，持倉頁新增堆疊式資產分布條；全部沿用終端自身配色
+- **接入點不再卡在中國內地** — 區域判定改為讀取 geotest 返回的國家，而非僅判斷其是否可達，並每 6 小時重新檢測，離開中國內地後不會繼續被路由到 `longbridge.cn`。`check` 每次運行都會重新檢測，實測兩個接入點並切換到明顯更優的一側；`.cn` 連接失敗時會提示如何手動指定區域
+- **修復：`ipo calendar` 無數據** — 上游聚合接口開始對所有賬戶返回空摘要，該命令已改用仍然可用的數據源重建
+- **修復：美股期權行情報錯更清晰** — `option quote` 現會說明需要「OPRA US Options」OpenAPI 行情權限並附上訂閱頁鏈接，不再只拋出 `301604`
+- **修復：`ipo detail` 局部降級** — 時間軸、申購資格與持股數據視為可選補充資訊，輔助接口不可用時仍會輸出核心資料（JSON 中為 `null`，`-v` 下給出告警）
+
 ### [v0.25.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.25.0)
 
 - **支援美國數據中心** — `auth login`（裝置碼流程與 `--auth-code`）支援美國賬戶授權，所有請求會按 token 自動路由到對應數據中心；`auth status` 展示當前 DC 區域

--- a/skills/longbridge/references/cli/overview.md
+++ b/skills/longbridge/references/cli/overview.md
@@ -57,13 +57,14 @@ longbridge auth logout   # Clear saved session token
 longbridge check    # Verify connectivity and token (no auth required)
 ```
 
-**China Mainland:** The CLI auto-detects CN by probing `geotest.lbkrs.com` on startup (non-blocking). Result cached at `~/.longbridge/openapi/region-cache`. CN users automatically use `.cn` endpoints.
+**China Mainland:** The CLI picks its access point from the country reported by `geotest.lbkrs.com`, caching the verdict at `~/.longbridge/openapi/region-cache` for 6 hours. China Mainland uses the `.cn` endpoints; everywhere else uses the global ones. `longbridge check` never reads that cache: it re-detects, measures both endpoints, and repins to whichever is decisively faster — so running it repairs a verdict that no longer matches reality, such as after a move or behind a split-tunnel proxy.
 
 ## Environment Variables
 
 | Variable         | Value     | Description                                                                                                                 |
 | ---------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `LONGBRIDGE_ENV` | `staging` | Switch all endpoints to the staging environment (`openapi.longbridge.xyz`). Useful for testing against non-production data. |
+| `LONGBRIDGE_REGION` | `cn` / `global` | Pin the API access point instead of detecting it. Use when detection lands on the wrong one — e.g. behind a proxy that exits in another country. |
 
 ```bash
 # Run any command against the staging environment


### PR DESCRIPTION
Adds the release-notes entry for what has landed on `longbridge-terminal` `main` since v0.25.0, in all three locales (en / zh-CN / zh-HK).

Covered:

- TUI settings modal (`Ctrl+,`), context-aware shortcut hints, mouse scrolling — longbridge/longbridge-terminal#272
- TUI visual refresh — longbridge/longbridge-terminal#273
- Access point no longer sticks to China Mainland — longbridge/longbridge-terminal#276
- `ipo calendar` returned no data — longbridge/longbridge-terminal#275
- Clearer error for US option quotes without OPRA access — longbridge/longbridge-terminal#271
- `ipo detail` degrades gracefully when an auxiliary endpoint is down — longbridge/longbridge-terminal#270

The version heading assumes **v0.26.0**, since the batch adds TUI features rather than only fixes. Say the word if it should ship as v0.25.1 and I will renumber.

Also refreshes the access-point paragraph in `skills/longbridge/references/cli/overview.md`, which still described detection as a non-blocking startup probe keyed off mere reachability, and adds `LONGBRIDGE_REGION` to the environment-variable table — the CLI now names that variable in its own error output.

The existing v0.25.0 entry is untouched; the diff is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)