### PR TITLE
docs(seo): add cross-domain internal links to longbridge.com

### DIFF
--- a/docs/en/docs/content/overview.md
+++ b/docs/en/docs/content/overview.md
@@ -7,7 +7,7 @@ slug: overview
 
 # Content API Overview
 
-Content APIs provide security news, community topic discussions, and sharelist management. All APIs are accessed via HTTP requests, or through the [SDK](https://open.longbridge.com/sdk).
+Content APIs provide [security news](https://longbridge.com/news), community topic discussions, and sharelist management. All APIs are accessed via HTTP requests, or through the [SDK](https://open.longbridge.com/sdk).
 
 <table>
     <thead>

--- a/docs/en/docs/fundamental/overview.md
+++ b/docs/en/docs/fundamental/overview.md
@@ -40,7 +40,7 @@ Market-level data including index components, broker positions, and anomaly scan
 
 ## CalendarContext
 
-Financial event calendars for planning around earnings, dividends, and macro releases.
+[Financial event calendars](https://longbridge.com/calendar/macrodata) for planning around earnings, dividends, and macro releases.
 
 | Method | Description |
 |---|---|

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -9,9 +9,9 @@ Longbridge Developers provides programmatic interfaces for investors with resear
 
 - **Quote** — [Real-time and historical quotes](https://longbridge.com/markets), market depth, candlesticks, options/warrants data, subscriptions
 - **Fundamental** — Company profiles, financials, valuations, analyst ratings, market data, calendars
-- **News & Contents** — [Market news](https://longbridge.com/en/news), community topics, sharelist management
+- **News & Contents** — [Market news](https://longbridge.com/en/news), [community topics](https://longbridge.com/topics), sharelist management
 - **Trade** — Create, amend, and cancel orders; query orders, executions, and assets
-- **Account** — Portfolio analysis, price alerts, DCA plans, watchlist
+- **Account** — Portfolio analysis, price alerts, DCA plans, [watchlist](https://longbridge.com/watchlist)
 - **CLI** — Command-line tool covering all of the above, plus quant backtesting and research
 - **MCP** — Model Context Protocol integration for AI assistant workflows
 

--- a/docs/en/docs/market/calendar/macro_calendar.md
+++ b/docs/en/docs/market/calendar/macro_calendar.md
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-Get upcoming macroeconomic data release events such as CPI, GDP, and Fed meetings.
+Get upcoming [macroeconomic data](https://longbridge.com/calendar/macrodata) release events such as CPI, GDP, and Fed meetings.
 
 <CliCommand>
 longbridge finance-calendar macrodata

--- a/docs/en/docs/screener/screener_indicators.md
+++ b/docs/en/docs/screener/screener_indicators.md
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-Get all indicator definitions supported by the stock screener, including keys, names, units, and available ranges. Use these to build custom filter conditions.
+Get all indicator definitions supported by the [stock screener](https://longbridge.com/screener), including keys, names, units, and available ranges. Use these to build custom filter conditions.
 
 Endpoint: `GET /v1/quote/ai/screener/indicators`
 

--- a/docs/zh-CN/docs/content/overview.md
+++ b/docs/zh-CN/docs/content/overview.md
@@ -8,7 +8,7 @@ slug: overview
 
 # 资讯与社区接口概览
 
-资讯与社区接口提供个股资讯、社区讨论和股单管理能力。所有接口均通过 HTTP 请求访问，也可以使用 [SDK](https://open.longbridge.com/sdk) 调用。
+资讯与社区接口提供[个股资讯](https://longbridge.com/news)、社区讨论和股单管理能力。所有接口均通过 HTTP 请求访问，也可以使用 [SDK](https://open.longbridge.com/sdk) 调用。
 
 <table>
     <thead>

--- a/docs/zh-CN/docs/fundamental/overview.md
+++ b/docs/zh-CN/docs/fundamental/overview.md
@@ -40,7 +40,7 @@ slug: overview
 
 ## CalendarContext
 
-财经事件日历，用于跟踪财报、分红和宏观数据发布。
+[财经事件日历](https://longbridge.com/calendar/macrodata)，用于跟踪财报、分红和宏观数据发布。
 
 | 方法 | 说明 |
 |---|---|

--- a/docs/zh-CN/docs/index.md
+++ b/docs/zh-CN/docs/index.md
@@ -9,9 +9,9 @@ Longbridge Developers 为有研发能力的投资者提供程序化接口，助�
 
 - **行情**（Quote）— [实时与历史行情](https://longbridge.com/markets)、盘口、K 线、期权/轮证数据、订阅推送
 - **基本面**（Fundamental）— 公司概况、财务数据、估值、分析师评级、市场数据、日历
-- **资讯与社区**（News & Contents）— [市场资讯](https://longbridge.com/en/news)、社区话题、自选股管理
+- **资讯与社区**（News & Contents）— [市场资讯](https://longbridge.com/en/news)、[社区话题](https://longbridge.com/topics)、自选股管理
 - **交易**（Trade）— 创建/修改/撤销订单，查询订单、成交、资产等
-- **账户**（Account）— 盈亏分析、股价提醒、定投计划、自选股
+- **账户**(Account) — 盈亏分析、股价提醒、定投计划、[自选股](https://longbridge.com/watchlist)
 - **CLI** — 命令行工具，覆盖以上所有功能，并额外支持量化回测与研究
 - **MCP** — Model Context Protocol，用于 AI 助手工作流集成
 

--- a/docs/zh-CN/docs/market/calendar/macro_calendar.md
+++ b/docs/zh-CN/docs/market/calendar/macro_calendar.md
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-获取即将发布的宏观经济数据，如 CPI、GDP 和美联储会议等。
+获取即将发布的[宏观经济数据](https://longbridge.com/calendar/macrodata)，如 CPI、GDP 和美联储会议等。
 
 <CliCommand>
 longbridge finance-calendar macrodata

--- a/docs/zh-CN/docs/screener/screener_indicators.md
+++ b/docs/zh-CN/docs/screener/screener_indicators.md
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-获取选股器支持的所有指标定义，包含键值、名称、单位和可用范围，可用于构建自定义筛选条件。
+获取[选股器](https://longbridge.com/screener)支持的所有指标定义，包含键值、名称、单位和可用范围，可用于构建自定义筛选条件。
 
 接口：`GET /v1/quote/ai/screener/indicators`
 

--- a/docs/zh-HK/docs/content/overview.md
+++ b/docs/zh-HK/docs/content/overview.md
@@ -8,7 +8,7 @@ slug: overview
 
 # 資訊與社區接口概覽
 
-資訊與社區接口提供個股資訊、社區討論和股單管理能力。所有接口均通過 HTTP 請求訪問，也可以使用 [SDK](https://open.longbridge.com/sdk) 調用。
+資訊與社區接口提供[個股資訊](https://longbridge.com/news)、社區討論和股單管理能力。所有接口均通過 HTTP 請求訪問，也可以使用 [SDK](https://open.longbridge.com/sdk) 調用。
 
 <table>
     <thead>

--- a/docs/zh-HK/docs/fundamental/overview.md
+++ b/docs/zh-HK/docs/fundamental/overview.md
@@ -40,7 +40,7 @@ slug: overview
 
 ## CalendarContext
 
-財經事件日历，用于跟踪财报、分红和宏觀数据發布。
+[財經事件日历](https://longbridge.com/calendar/macrodata)，用于跟踪财报、分红和宏觀数据發布。
 
 | 方法 | 说明 |
 |---|---|

--- a/docs/zh-HK/docs/index.md
+++ b/docs/zh-HK/docs/index.md
@@ -9,9 +9,9 @@ Longbridge Developers 為有研發能力的投資者提供程序化接口，助�
 
 - **行情**（Quote）— [實時與歷史行情](https://longbridge.com/markets)、盤口、K 線、期權/輪證數據、訂閱推送
 - **基本面**（Fundamental）— 公司概況、財務數據、估值、分析師評級、市場數據、日曆
-- **資訊與社區**（News & Contents）— [市場資訊](https://longbridge.com/en/news)、社區話題、自選股管理
+- **資訊與社區**（News & Contents）— [市場資訊](https://longbridge.com/en/news)、[社區話題](https://longbridge.com/topics)、自選股管理
 - **交易**（Trade）— 創建/修改/撤銷訂單，查詢訂單、成交、資產等
-- **帳戶**（Account）— 盈虧分析、股價提醒、定投計劃、自選股
+- **帳戶**（Account）— 盈虧分析、股價提醒、定投計劃、[自選股](https://longbridge.com/watchlist)
 - **CLI** — 命令行工具，覆蓋以上所有功能，並額外支持量化回測與研究
 - **MCP** — Model Context Protocol，用於 AI 助手工作流集成
 

--- a/docs/zh-HK/docs/market/calendar/macro_calendar.md
+++ b/docs/zh-HK/docs/market/calendar/macro_calendar.md
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-獲取即將發布的宏觀經濟數據，如 CPI、GDP 和美聯儲會議等。
+獲取即將發布的[宏觀經濟數據](https://longbridge.com/calendar/macrodata)，如 CPI、GDP 和美聯儲會議等。
 
 <CliCommand>
 longbridge finance-calendar macrodata

--- a/docs/zh-HK/docs/screener/screener_indicators.md
+++ b/docs/zh-HK/docs/screener/screener_indicators.md
@@ -10,7 +10,7 @@ highlight_theme: ''
 headingLevel: 2
 ---
 
-獲取選股器支持的所有指標定義，包含鍵值、名稱、單位和可用範圍，可用於構建自定義篩選條件。
+獲取[選股器](https://longbridge.com/screener)支持的所有指標定義，包含鍵值、名稱、單位和可用範圍，可用於構建自定義篩選條件。
 
 接口：`GET /v1/quote/ai/screener/indicators`
 


### PR DESCRIPTION
Wrap 6 existing terms across the docs as hyperlinks pointing to the matching longbridge.com pages (per SEO team requirement doc). Targets are unprefixed so longbridge.com auto-routes by browser locale; the same URL is used from all three language sites.

- docs index: community topics -> /topics; watchlist -> /watchlist
- screener/screener_indicators: stock screener -> /screener
- market/calendar/macro_calendar: macroeconomic data -> /calendar/macrodata
- fundamental/overview: Financial event calendars -> /calendar/macrodata
- content/overview: security news -> /news