### PR TITLE
feat(skill): add Claude connector alongside ChatGPT

### DIFF
--- a/docs/.vitepress/theme/components/NewHomePage/index.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/index.vue
@@ -1,11 +1,49 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import AppNav from '../AppNav.vue'
 import AppFooter from '../AppFooter.vue'
 import { localePath } from '../../utils/i18n'
 import { useData } from 'vitepress'
 
 const { lang } = useData()
+
+const subtitleRef = ref<HTMLElement | null>(null)
+let channelsObserver: IntersectionObserver | null = null
+
+const handleSubtitleAnimationEnd = (e: AnimationEvent) => {
+  if (e.animationName === 'home-channels-reveal' && e.target === subtitleRef.value) {
+    subtitleRef.value?.classList.remove('is-visible')
+  }
+}
+
+onMounted(() => {
+  const el = subtitleRef.value
+  if (!el) return
+  if (typeof IntersectionObserver === 'undefined') {
+    el.classList.add('is-visible')
+    return
+  }
+  el.addEventListener('animationend', handleSubtitleAnimationEnd)
+  channelsObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          // 重启动画：先摘掉 class + 强制 reflow，再挂回来
+          el.classList.remove('is-visible')
+          void el.offsetWidth
+          el.classList.add('is-visible')
+        }
+      })
+    },
+    { threshold: 0, rootMargin: '-40% 0px -40% 0px' }
+  )
+  channelsObserver.observe(el)
+})
+
+onBeforeUnmount(() => {
+  channelsObserver?.disconnect()
+  subtitleRef.value?.removeEventListener('animationend', handleSubtitleAnimationEnd)
+})
 
 const CHATGPT_APP_URL = 'https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef'
 const CLAUDE_CONNECTOR_URL = 'https://claude.ai/directory/connectors/longbridge-mcp'
@@ -27,24 +65,20 @@ const LOCALE = {
       ],
     },
     channels: {
-      eyebrow: 'NOW AVAILABLE IN',
+      eyebrow: 'OFFICIAL INTEGRATION · NOW LIVE',
       title: 'ChatGPT × Claude',
       tagline: 'AI that reads the market.',
       subtitle:
-        'Longbridge lives natively in ChatGPT and Claude. Ask a ticker, screen ideas, or drop into your positions — no keys, no context switch.',
+        '<span class="k k-lb">Longbridge</span> is live on <span class="k k-gpt">ChatGPT Apps</span> and <span class="k k-claude">Claude Connectors</span> — check quotes, screen ideas, view positions. One-tap OAuth, no API keys.',
       partners: [
         {
           key: 'chatgpt',
           brand: 'ChatGPT',
-          tag: 'Official App',
-          prompt: 'Call @longbridge in any ChatGPT conversation',
           cta: 'Open in ChatGPT',
         },
         {
           key: 'claude',
           brand: 'Claude',
-          tag: 'Connector',
-          prompt: 'One-tap add from Claude’s Connector directory',
           cta: 'Add Claude Connector',
         },
       ],
@@ -234,24 +268,20 @@ const LOCALE = {
       ],
     },
     channels: {
-      eyebrow: '现已支持',
+      eyebrow: '官方集成 · 现已上线',
       title: 'ChatGPT × Claude',
       tagline: '让 AI 读懂市场。',
       subtitle:
-        'Longbridge 已原生集成到 ChatGPT 与 Claude。查行情、筛股票、看持仓，无需 API Key、无需切换上下文。',
+        '<span class="k k-lb">Longbridge</span> 已上架 <span class="k k-gpt">ChatGPT Apps</span> 与 <span class="k k-claude">Claude Connectors</span> —— 查行情、筛股票、看持仓，OAuth 授权即用，无需 API Key。',
       partners: [
         {
           key: 'chatgpt',
           brand: 'ChatGPT',
-          tag: '官方 App',
-          prompt: '在对话里 @longbridge 直接唤起',
           cta: '在 ChatGPT 打开',
         },
         {
           key: 'claude',
           brand: 'Claude',
-          tag: 'Connector',
-          prompt: '从 Connector 目录一键添加',
           cta: '添加 Claude Connector',
         },
       ],
@@ -424,24 +454,20 @@ const LOCALE = {
       ],
     },
     channels: {
-      eyebrow: '現已支援',
+      eyebrow: '官方整合 · 現已上線',
       title: 'ChatGPT × Claude',
       tagline: '讓 AI 讀懂市場。',
       subtitle:
-        'Longbridge 已原生整合至 ChatGPT 與 Claude。查行情、篩股票、看持倉，無需 API Key、無需切換情境。',
+        '<span class="k k-lb">Longbridge</span> 已上架 <span class="k k-gpt">ChatGPT Apps</span> 與 <span class="k k-claude">Claude Connectors</span> —— 查行情、篩股票、看持倉，OAuth 授權即用，無需 API Key。',
       partners: [
         {
           key: 'chatgpt',
           brand: 'ChatGPT',
-          tag: '官方 App',
-          prompt: '在對話裡 @longbridge 直接喚起',
           cta: '在 ChatGPT 開啟',
         },
         {
           key: 'claude',
           brand: 'Claude',
-          tag: 'Connector',
-          prompt: '從 Connector 目錄一鍵加入',
           cta: '加入 Claude Connector',
         },
       ],
@@ -1455,7 +1481,11 @@ const GETSTARTED = [
                 </span>
                 ChatGPT
               </span>
-              <span class="home-channels-title-x" aria-hidden="true">×</span>
+              <span class="home-channels-title-x" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round">
+                  <path d="M6 6l12 12M18 6L6 18" />
+                </svg>
+              </span>
               <span class="home-channels-title-brand">
                 <span class="home-channels-title-logo home-channels-title-logo--claude" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="currentColor">
@@ -1468,7 +1498,7 @@ const GETSTARTED = [
             </span>
             <span class="home-channels-tagline">{{ content.channels.tagline }}</span>
           </h2>
-          <p class="home-channels-sub">{{ content.channels.subtitle }}</p>
+          <p ref="subtitleRef" class="home-channels-sub" v-html="content.channels.subtitle"></p>
         </div>
 
         <div class="home-channels-cards">
@@ -1494,10 +1524,6 @@ const GETSTARTED = [
               </span>
               <div class="home-channel-card-titles">
                 <div class="home-channel-card-brand">{{ p.brand }}</div>
-                <div class="home-channel-card-tag">
-                  <span class="home-channel-card-live" />
-                  {{ p.tag }}
-                </div>
               </div>
               <div class="home-channel-card-cta">
                 <span>{{ p.cta }}</span>
@@ -1516,12 +1542,6 @@ const GETSTARTED = [
               </div>
             </div>
 
-            <div class="home-channel-card-preview">
-              <div class="home-channel-card-row home-channel-card-row--prompt">
-                <span class="home-channel-card-bullet">›</span>
-                <span class="home-channel-card-text">{{ p.prompt }}</span>
-              </div>
-            </div>
           </a>
         </div>
       </div>
@@ -2498,22 +2518,22 @@ const GETSTARTED = [
 }
 .home-channels-glow {
   position: absolute;
-  width: 620px;
-  height: 620px;
+  width: 420px;
+  height: 420px;
   border-radius: 999px;
-  filter: blur(120px);
-  opacity: 0.32;
+  filter: blur(90px);
+  opacity: 0.28;
   z-index: 0;
   pointer-events: none;
 }
 .home-channels-glow--gpt {
-  top: -180px;
-  left: -160px;
+  top: -80px;
+  left: -60px;
   background: radial-gradient(circle, #10a37f 0%, transparent 65%);
 }
 .home-channels-glow--claude {
-  bottom: -220px;
-  right: -180px;
+  bottom: -120px;
+  right: -80px;
   background: radial-gradient(circle, #d97757 0%, transparent 65%);
 }
 
@@ -2563,9 +2583,19 @@ const GETSTARTED = [
   color: #d97757;
 }
 .home-channels-title-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.5em;
+  height: 0.5em;
   color: var(--lb-fg-3);
-  font-weight: 300;
-  margin: 0 0.05em;
+  opacity: 0.55;
+  margin: 0 0.1em;
+}
+.home-channels-title-x svg {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 .home-channels-tagline {
   display: block;
@@ -2577,16 +2607,99 @@ const GETSTARTED = [
 }
 .home-channels-sub {
   margin: 0 auto;
-  max-width: 640px;
-  font-size: 16px;
-  line-height: 1.6;
-  color: var(--lb-fg-3);
+  max-width: 780px;
+  font-size: 17px;
+  line-height: 1.8;
+  font-weight: 500;
+  color: var(--lb-fg-2);
+}
+.home-channels-sub .k {
+  font-size: 1.3em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.home-channels-sub .k-lb {
+  color: var(--lb-fg-1);
+}
+.home-channels-sub .k-gpt {
+  color: var(--lb-brand);
+}
+.home-channels-sub .k-claude {
+  color: #d97757;
+}
+
+.home-channels-sub.is-visible,
+.home-channels-sub.is-visible .k {
+  background-size: 300% 100%;
+  background-position: 100% 50%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: home-channels-reveal 5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.home-channels-sub.is-visible {
+  background-image: linear-gradient(
+    105deg,
+    var(--lb-fg-2) 0%,
+    var(--lb-fg-2) 42%,
+    #ffffff 50%,
+    var(--lb-fg-2) 58%,
+    var(--lb-fg-2) 100%
+  );
+}
+.home-channels-sub.is-visible .k-lb {
+  background-image: linear-gradient(
+    105deg,
+    var(--lb-fg-1) 0%,
+    var(--lb-fg-1) 42%,
+    #ffffff 50%,
+    var(--lb-fg-1) 58%,
+    var(--lb-fg-1) 100%
+  );
+}
+.home-channels-sub.is-visible .k-gpt {
+  background-image: linear-gradient(
+    105deg,
+    var(--lb-brand) 0%,
+    var(--lb-brand) 42%,
+    #ffffff 50%,
+    var(--lb-brand) 58%,
+    var(--lb-brand) 100%
+  );
+}
+.home-channels-sub.is-visible .k-claude {
+  background-image: linear-gradient(
+    105deg,
+    #d97757 0%,
+    #d97757 42%,
+    #ffffff 50%,
+    #d97757 58%,
+    #d97757 100%
+  );
+}
+@keyframes home-channels-reveal {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-channels-sub.is-visible,
+  .home-channels-sub.is-visible .k {
+    animation: none;
+    background: none;
+    -webkit-text-fill-color: currentColor;
+  }
 }
 
 .home-channels-cards {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 20px;
+  max-width: 760px;
+  margin: 0 auto;
 }
 .home-channel-card {
   position: relative;
@@ -2644,29 +2757,31 @@ const GETSTARTED = [
 
 .home-channel-card-glow {
   position: absolute;
-  top: -80px;
-  right: -80px;
-  width: 260px;
-  height: 260px;
+  top: -50px;
+  right: -50px;
+  width: 160px;
+  height: 160px;
   border-radius: 999px;
   background: radial-gradient(circle, var(--card-accent) 0%, transparent 70%);
-  filter: blur(60px);
-  opacity: 0.35;
+  filter: blur(40px);
+  opacity: 0.28;
   z-index: 0;
   pointer-events: none;
   transition: opacity 0.25s ease;
 }
 .home-channel-card:hover .home-channel-card-glow {
-  opacity: 0.55;
+  opacity: 0.45;
 }
 
 .home-channel-card-head {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
   z-index: 1;
-  flex-wrap: wrap;
+}
+.home-channel-card-logo {
+  flex-shrink: 0;
 }
 .home-channel-card-logo {
   display: inline-flex;
@@ -2697,8 +2812,8 @@ const GETSTARTED = [
 .home-channel-card-cta {
   margin-left: auto;
   white-space: nowrap;
-  align-self: flex-start;
-  margin-top: 6px;
+  align-self: center;
+  flex-shrink: 0;
 }
 .home-channel-card-brand {
   font-size: 20px;
@@ -2772,6 +2887,9 @@ const GETSTARTED = [
 }
 .home-channel-card:hover .home-channel-card-cta {
   transform: translateX(4px);
+}
+.home-channel-card--chatgpt .home-channel-card-cta {
+  color: var(--lb-brand);
 }
 
 @media (max-width: 860px) {

--- a/docs/.vitepress/theme/components/NewHomePage/index.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/index.vue
@@ -28,7 +28,26 @@ const LOCALE = {
     },
     channels: {
       eyebrow: 'NOW AVAILABLE IN',
-      title: 'Use Longbridge natively inside ChatGPT and Claude.',
+      title: 'ChatGPT × Claude',
+      tagline: 'AI that reads the market.',
+      subtitle:
+        'Longbridge lives natively in ChatGPT and Claude. Ask a ticker, screen ideas, or drop into your positions — no keys, no context switch.',
+      partners: [
+        {
+          key: 'chatgpt',
+          brand: 'ChatGPT',
+          tag: 'Official App',
+          prompt: 'Call @longbridge in any ChatGPT conversation',
+          cta: 'Open in ChatGPT',
+        },
+        {
+          key: 'claude',
+          brand: 'Claude',
+          tag: 'Connector',
+          prompt: 'One-tap add from Claude’s Connector directory',
+          cta: 'Add Claude Connector',
+        },
+      ],
     },
     features: {
       eyebrow: 'FEATURES',
@@ -216,7 +235,26 @@ const LOCALE = {
     },
     channels: {
       eyebrow: '现已支持',
-      title: '在 ChatGPT 与 Claude 中畅用 Longbridge。',
+      title: 'ChatGPT × Claude',
+      tagline: '让 AI 读懂市场。',
+      subtitle:
+        'Longbridge 已原生集成到 ChatGPT 与 Claude。查行情、筛股票、看持仓，无需 API Key、无需切换上下文。',
+      partners: [
+        {
+          key: 'chatgpt',
+          brand: 'ChatGPT',
+          tag: '官方 App',
+          prompt: '在对话里 @longbridge 直接唤起',
+          cta: '在 ChatGPT 打开',
+        },
+        {
+          key: 'claude',
+          brand: 'Claude',
+          tag: 'Connector',
+          prompt: '从 Connector 目录一键添加',
+          cta: '添加 Claude Connector',
+        },
+      ],
     },
     features: {
       eyebrow: '功能特性',
@@ -387,7 +425,26 @@ const LOCALE = {
     },
     channels: {
       eyebrow: '現已支援',
-      title: '在 ChatGPT 與 Claude 中暢用 Longbridge。',
+      title: 'ChatGPT × Claude',
+      tagline: '讓 AI 讀懂市場。',
+      subtitle:
+        'Longbridge 已原生整合至 ChatGPT 與 Claude。查行情、篩股票、看持倉，無需 API Key、無需切換情境。',
+      partners: [
+        {
+          key: 'chatgpt',
+          brand: 'ChatGPT',
+          tag: '官方 App',
+          prompt: '在對話裡 @longbridge 直接喚起',
+          cta: '在 ChatGPT 開啟',
+        },
+        {
+          key: 'claude',
+          brand: 'Claude',
+          tag: 'Connector',
+          prompt: '從 Connector 目錄一鍵加入',
+          cta: '加入 Claude Connector',
+        },
+      ],
     },
     features: {
       eyebrow: '功能特性',
@@ -1381,32 +1438,91 @@ const GETSTARTED = [
 
     <!-- ===== Available in ChatGPT & Claude ===== -->
     <section class="home-channels">
-      <div class="section-inner">
+      <div class="home-channels-grid-bg" aria-hidden="true" />
+      <div class="home-channels-glow home-channels-glow--gpt" aria-hidden="true" />
+      <div class="home-channels-glow home-channels-glow--claude" aria-hidden="true" />
+      <div class="section-inner home-channels-inner">
         <div class="home-channels-head">
-          <div style="max-width: 620px">
-            <span class="eyebrow">{{ content.channels.eyebrow }}</span>
-            <h2 class="h-section" style="margin-top: 16px">{{ content.channels.title }}</h2>
-          </div>
-          <div class="home-channels-chips">
-            <a class="home-channel-chip" :href="CHATGPT_APP_URL" target="_blank" rel="noreferrer">
-              <span class="home-channel-logo" style="color: #10a37f">
-                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <span class="eyebrow">{{ content.channels.eyebrow }}</span>
+          <h2 class="h-section home-channels-title">
+            <span class="home-channels-title-line">
+              <span class="home-channels-title-brand">
+                <span class="home-channels-title-logo home-channels-title-logo--gpt" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path
+                      d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+                  </svg>
+                </span>
+                ChatGPT
+              </span>
+              <span class="home-channels-title-x" aria-hidden="true">×</span>
+              <span class="home-channels-title-brand">
+                <span class="home-channels-title-logo home-channels-title-logo--claude" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor">
+                    <path
+                      d="M4.709 15.955l4.72-2.647.079-.23-.079-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
+                  </svg>
+                </span>
+                Claude
+              </span>
+            </span>
+            <span class="home-channels-tagline">{{ content.channels.tagline }}</span>
+          </h2>
+          <p class="home-channels-sub">{{ content.channels.subtitle }}</p>
+        </div>
+
+        <div class="home-channels-cards">
+          <a
+            v-for="p in content.channels.partners"
+            :key="p.key"
+            class="home-channel-card"
+            :class="`home-channel-card--${p.key}`"
+            :href="p.key === 'chatgpt' ? CHATGPT_APP_URL : CLAUDE_CONNECTOR_URL"
+            target="_blank"
+            rel="noreferrer">
+            <div class="home-channel-card-glow" aria-hidden="true" />
+            <div class="home-channel-card-head">
+              <span class="home-channel-card-logo" :class="`home-channel-card-logo--${p.key}`">
+                <svg v-if="p.key === 'chatgpt'" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path
                     d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
                 </svg>
-              </span>
-              <span>ChatGPT</span>
-            </a>
-            <a class="home-channel-chip" :href="CLAUDE_CONNECTOR_URL" target="_blank" rel="noreferrer">
-              <span class="home-channel-logo" style="color: #d97757">
-                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <svg v-else viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path
-                    d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-7.258 0h3.767L16.906 20h-3.674l-1.343-3.461H5.017l-1.344 3.46H0L6.57 3.522zm4.132 9.959L8.453 7.687 6.205 13.48H10.7z" />
+                    d="M4.709 15.955l4.72-2.647.079-.23-.079-.128H9.2l-.79-.048-2.698-.073-2.339-.097-2.266-.122-.571-.121L0 11.784l.055-.352.48-.321.686.06 1.52.103 2.278.158 1.652.097 2.449.255h.389l.055-.157-.134-.098-.103-.097-2.358-1.596-2.552-1.688-1.336-.972-.724-.491-.364-.462-.158-1.008.656-.722.881.06.225.061.893.686 1.908 1.476 2.491 1.833.365.304.145-.103.019-.073-.164-.274-1.355-2.446-1.446-2.49-.644-1.032-.17-.619a2.97 2.97 0 01-.104-.729L6.283.134 6.696 0l.996.134.42.364.62 1.414 1.002 2.229 1.555 3.03.456.898.243.832.091.255h.158V9.01l.128-1.706.237-2.095.23-2.695.08-.76.376-.91.747-.492.584.28.48.685-.067.444-.286 1.851-.559 2.903-.364 1.942h.212l.243-.242.985-1.306 1.652-2.064.73-.82.85-.904.547-.431h1.033l.76 1.129-.34 1.166-1.064 1.347-.881 1.142-1.264 1.7-.79 1.36.073.11.188-.02 2.856-.606 1.543-.28 1.841-.315.833.388.091.395-.328.807-1.969.486-2.309.462-3.439.813-.042.03.049.061 1.549.146.662.036h1.622l3.02.225.79.522.474.638-.079.485-1.215.62-1.64-.389-3.829-.91-1.312-.329h-.182v.11l1.093 1.068 2.006 1.81 2.509 2.33.127.578-.322.455-.34-.049-2.205-1.657-.851-.747-1.926-1.62h-.128v.17l.444.649 2.345 3.521.122 1.08-.17.353-.608.213-.668-.122-1.374-1.925-1.415-2.167-1.143-1.943-.14.08-.674 7.254-.316.37-.729.28-.607-.461-.322-.747.322-1.476.389-1.924.315-1.53.286-1.9.17-.632-.012-.042-.14.018-1.434 1.967-2.18 2.945-1.726 1.845-.414.164-.717-.37.067-.662.401-.589 2.388-3.036 1.44-1.882.93-1.086-.006-.158h-.055L4.132 18.56l-1.13.146-.487-.456.061-.746.231-.243 1.908-1.312-.006.006z" />
                 </svg>
               </span>
-              <span>Claude</span>
-            </a>
-          </div>
+              <div class="home-channel-card-titles">
+                <div class="home-channel-card-brand">{{ p.brand }}</div>
+                <div class="home-channel-card-tag">
+                  <span class="home-channel-card-live" />
+                  {{ p.tag }}
+                </div>
+              </div>
+              <div class="home-channel-card-cta">
+                <span>{{ p.cta }}</span>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round">
+                  <path d="M5 12h14" />
+                  <path d="m12 5 7 7-7 7" />
+                </svg>
+              </div>
+            </div>
+
+            <div class="home-channel-card-preview">
+              <div class="home-channel-card-row home-channel-card-row--prompt">
+                <span class="home-channel-card-bullet">›</span>
+                <span class="home-channel-card-text">{{ p.prompt }}</span>
+              </div>
+            </div>
+          </a>
         </div>
       </div>
     </section>
@@ -2340,59 +2456,339 @@ const GETSTARTED = [
 
 /* ===== Available in ChatGPT & Claude ===== */
 .home-channels {
-  padding: 80px 24px 0;
+  position: relative;
+  padding: 120px 24px 80px;
+  overflow: hidden;
+  isolation: isolate;
 }
+.home-channels::before,
+.home-channels::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 180px;
+  pointer-events: none;
+  z-index: 1;
+}
+.home-channels::before {
+  top: 0;
+  background: linear-gradient(to bottom, var(--lb-bg-1), transparent);
+}
+.home-channels::after {
+  bottom: 0;
+  background: linear-gradient(to top, var(--lb-bg-1), transparent);
+}
+.home-channels-inner {
+  position: relative;
+  z-index: 2;
+}
+.home-channels-grid-bg {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(to right, color-mix(in srgb, var(--lb-fg-1) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in srgb, var(--lb-fg-1) 6%, transparent) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: radial-gradient(ellipse 70% 55% at 50% 45%, #000 0%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse 70% 55% at 50% 45%, #000 0%, transparent 75%);
+  opacity: 0.55;
+  z-index: 0;
+  pointer-events: none;
+}
+.home-channels-glow {
+  position: absolute;
+  width: 620px;
+  height: 620px;
+  border-radius: 999px;
+  filter: blur(120px);
+  opacity: 0.32;
+  z-index: 0;
+  pointer-events: none;
+}
+.home-channels-glow--gpt {
+  top: -180px;
+  left: -160px;
+  background: radial-gradient(circle, #10a37f 0%, transparent 65%);
+}
+.home-channels-glow--claude {
+  bottom: -220px;
+  right: -180px;
+  background: radial-gradient(circle, #d97757 0%, transparent 65%);
+}
+
 .home-channels-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  gap: 24px;
+  text-align: center;
+  max-width: 780px;
+  margin: 0 auto 56px;
 }
-.home-channels-chips {
-  display: flex;
-  gap: 12px;
+@keyframes home-channels-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
-.home-channel-chip {
+.home-channels-title {
+  margin: 18px 0 20px;
+  font-size: clamp(26px, 3.2vw, 40px);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+.home-channels-title-line {
   display: inline-flex;
   align-items: center;
-  gap: 9px;
-  padding: 10px 18px;
-  border-radius: 999px;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.32em;
+}
+.home-channels-title-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28em;
+}
+.home-channels-title-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+}
+.home-channels-title-logo svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.home-channels-title-logo--gpt {
+  color: var(--lb-fg-1);
+}
+.home-channels-title-logo--claude {
+  color: #d97757;
+}
+.home-channels-title-x {
+  color: var(--lb-fg-3);
+  font-weight: 300;
+  margin: 0 0.05em;
+}
+.home-channels-tagline {
+  display: block;
+  margin-top: 10px;
+  font-size: 0.5em;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--lb-fg-3);
+}
+.home-channels-sub {
+  margin: 0 auto;
+  max-width: 640px;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--lb-fg-3);
+}
+
+.home-channels-cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+.home-channel-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px;
+  border-radius: 20px;
   border: 1px solid var(--app-card-stroke);
   background: var(--lb-bg-1);
   color: var(--lb-fg-1);
-  font-size: 14px;
-  font-weight: 600;
   text-decoration: none;
+  overflow: hidden;
+  isolation: isolate;
   transition:
-    transform 0.15s,
-    border-color 0.15s,
-    box-shadow 0.15s;
+    transform 0.25s ease,
+    border-color 0.25s ease,
+    box-shadow 0.25s ease;
 }
-.home-channel-chip:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in srgb, var(--lb-brand) 40%, var(--app-card-stroke));
-  box-shadow: 0 8px 20px -10px rgba(15, 17, 21, 0.22);
+.home-channel-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--card-accent) 55%, transparent),
+    transparent 45%,
+    transparent 70%,
+    color-mix(in srgb, var(--card-accent) 25%, transparent)
+  );
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  z-index: 2;
 }
-.home-channel-logo {
+.home-channel-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 30px 60px -32px color-mix(in srgb, var(--card-accent) 60%, rgba(15, 17, 21, 0.28));
+}
+.home-channel-card:hover::before {
+  opacity: 1;
+}
+.home-channel-card--chatgpt {
+  --card-accent: #10a37f;
+}
+.home-channel-card--claude {
+  --card-accent: #d97757;
+}
+
+.home-channel-card-glow {
+  position: absolute;
+  top: -80px;
+  right: -80px;
+  width: 260px;
+  height: 260px;
+  border-radius: 999px;
+  background: radial-gradient(circle, var(--card-accent) 0%, transparent 70%);
+  filter: blur(60px);
+  opacity: 0.35;
+  z-index: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+.home-channel-card:hover .home-channel-card-glow {
+  opacity: 0.55;
+}
+
+.home-channel-card-head {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  z-index: 1;
+  flex-wrap: wrap;
+}
+.home-channel-card-logo {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
+  color: var(--card-accent);
 }
-.home-channel-logo svg {
-  width: 18px;
-  height: 18px;
+.home-channel-card-logo svg {
+  width: 24px;
+  height: 24px;
   display: block;
 }
-@media (max-width: 640px) {
+.home-channel-card-logo--chatgpt {
+  color: var(--lb-fg-1);
+  background: color-mix(in srgb, var(--lb-fg-1) 8%, transparent);
+}
+.home-channel-card-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.home-channel-card-cta {
+  margin-left: auto;
+  white-space: nowrap;
+  align-self: flex-start;
+  margin-top: 6px;
+}
+.home-channel-card-brand {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--lb-fg-1);
+}
+.home-channel-card-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--lb-fg-3);
+}
+.home-channel-card-live {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--card-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--card-accent) 22%, transparent);
+  animation: home-channels-pulse 2.4s ease-in-out infinite;
+}
+
+.home-channel-card-preview {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--lb-fg-1) 4%, transparent);
+  font-family: var(--lb-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+.home-channel-card-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+}
+.home-channel-card-bullet {
+  flex: 0 0 auto;
+  color: color-mix(in srgb, var(--lb-fg-3) 80%, transparent);
+  font-weight: 600;
+  line-height: 1.5;
+}
+.home-channel-card-bullet--reply {
+  color: var(--card-accent);
+  font-size: 11px;
+  transform: translateY(2px);
+}
+.home-channel-card-text {
+  color: var(--lb-fg-2, var(--lb-fg-1));
+  word-break: break-word;
+}
+.home-channel-card-text--reply {
+  color: var(--lb-fg-1);
+}
+
+.home-channel-card-cta {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--card-accent);
+  transition: transform 0.2s ease;
+}
+.home-channel-card:hover .home-channel-card-cta {
+  transform: translateX(4px);
+}
+
+@media (max-width: 860px) {
   .home-channels {
-    padding: 48px 16px 0;
+    padding: 72px 16px 24px;
   }
-  .home-channels-chips {
-    width: 100%;
+  .home-channels-cards {
+    grid-template-columns: 1fr;
   }
-  .home-channel-chip {
-    flex: 1 1 0;
-    justify-content: center;
+  .home-channels-head {
+    margin-bottom: 40px;
+  }
+  .home-channels-title {
+    font-size: clamp(24px, 6.8vw, 32px);
+  }
+  .home-channel-card {
+    padding: 24px;
   }
 }
 </style>

--- a/docs/.vitepress/theme/components/NewHomePage/index.vue
+++ b/docs/.vitepress/theme/components/NewHomePage/index.vue
@@ -7,6 +7,9 @@ import { useData } from 'vitepress'
 
 const { lang } = useData()
 
+const CHATGPT_APP_URL = 'https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef'
+const CLAUDE_CONNECTOR_URL = 'https://claude.ai/directory/connectors/longbridge-mcp'
+
 const LOCALE = {
   en: {
     hero: {
@@ -22,6 +25,10 @@ const LOCALE = {
         { u: 'endpoints', d: 'Quote · Trade · Research · News' },
         { u: 'OpenAPI access', d: 'No monthly fees' },
       ],
+    },
+    channels: {
+      eyebrow: 'NOW AVAILABLE IN',
+      title: 'Use Longbridge natively inside ChatGPT and Claude.',
     },
     features: {
       eyebrow: 'FEATURES',
@@ -207,6 +214,10 @@ const LOCALE = {
         { u: 'OpenAPI 接入费', d: '集成账户免费' },
       ],
     },
+    channels: {
+      eyebrow: '现已支持',
+      title: '在 ChatGPT 与 Claude 中畅用 Longbridge。',
+    },
     features: {
       eyebrow: '功能特性',
       title: '一切所需，涵盖行情分析、量化研究与智能交易',
@@ -373,6 +384,10 @@ const LOCALE = {
         { u: '+ 個接口', d: '行情 · 交易 · 研究 · 資訊' },
         { u: 'OpenAPI 接入費', d: '整合帳戶免費' },
       ],
+    },
+    channels: {
+      eyebrow: '現已支援',
+      title: '在 ChatGPT 與 Claude 中暢用 Longbridge。',
     },
     features: {
       eyebrow: '功能特性',
@@ -1364,6 +1379,38 @@ const GETSTARTED = [
       </div>
     </section>
 
+    <!-- ===== Available in ChatGPT & Claude ===== -->
+    <section class="home-channels">
+      <div class="section-inner">
+        <div class="home-channels-head">
+          <div style="max-width: 620px">
+            <span class="eyebrow">{{ content.channels.eyebrow }}</span>
+            <h2 class="h-section" style="margin-top: 16px">{{ content.channels.title }}</h2>
+          </div>
+          <div class="home-channels-chips">
+            <a class="home-channel-chip" :href="CHATGPT_APP_URL" target="_blank" rel="noreferrer">
+              <span class="home-channel-logo" style="color: #10a37f">
+                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path
+                    d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+                </svg>
+              </span>
+              <span>ChatGPT</span>
+            </a>
+            <a class="home-channel-chip" :href="CLAUDE_CONNECTOR_URL" target="_blank" rel="noreferrer">
+              <span class="home-channel-logo" style="color: #d97757">
+                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path
+                    d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-7.258 0h3.767L16.906 20h-3.674l-1.343-3.461H5.017l-1.344 3.46H0L6.57 3.522zm4.132 9.959L8.453 7.687 6.205 13.48H10.7z" />
+                </svg>
+              </span>
+              <span>Claude</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- ===== Products matrix ===== -->
     <section class="section">
       <div class="section-inner">
@@ -2289,5 +2336,63 @@ const GETSTARTED = [
   background: var(--lb-bg-1);
   color: var(--lb-fg-1);
   font-family: var(--lb-font-sans);
+}
+
+/* ===== Available in ChatGPT & Claude ===== */
+.home-channels {
+  padding: 80px 24px 0;
+}
+.home-channels-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+.home-channels-chips {
+  display: flex;
+  gap: 12px;
+}
+.home-channel-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--app-card-stroke);
+  background: var(--lb-bg-1);
+  color: var(--lb-fg-1);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    transform 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.home-channel-chip:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--lb-brand) 40%, var(--app-card-stroke));
+  box-shadow: 0 8px 20px -10px rgba(15, 17, 21, 0.22);
+}
+.home-channel-logo {
+  display: inline-flex;
+}
+.home-channel-logo svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+@media (max-width: 640px) {
+  .home-channels {
+    padding: 48px 16px 0;
+  }
+  .home-channels-chips {
+    width: 100%;
+  }
+  .home-channel-chip {
+    flex: 1 1 0;
+    justify-content: center;
+  }
 }
 </style>

--- a/docs/.vitepress/theme/components/Skill.vue
+++ b/docs/.vitepress/theme/components/Skill.vue
@@ -15,6 +15,7 @@ const zhHKLocale = augmentLocale(_zhHKLocale)
 
 const { lang } = useData()
 const CHATGPT_APP_URL = 'https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef'
+const CLAUDE_CONNECTOR_URL = 'https://claude.ai/directory/connectors/longbridge-mcp'
 
 const LOCALE = {
   en: {
@@ -24,10 +25,11 @@ const LOCALE = {
       title2: 'Unlock market insights, deep research and intelligent trading for your AI.',
       desc: 'For Claude Code, Codex, Gemini, and other agents, Longbridge Skill lets your AI <a href="https://longbridge.com/en/screener" target="_blank" rel="noreferrer">screen stocks</a>, decode earnings, track insider moves, and place orders in plain conversation.',
       chatgptLine:
-        '<a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">ChatGPT</a> can install <a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">Longbridge</a> directly and use it with <code>@longbridge</code>.',
+        '<a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">ChatGPT</a> and <a class="skill-chatgpt-link" href="https://claude.ai/directory/connectors/longbridge-mcp">Claude</a> can install Longbridge directly — use <code>@longbridge</code> in ChatGPT, or the connector in Claude.',
       tabConnect: 'Connect AI',
       tabPrompt: 'Copy command',
       tabChatGPT: 'ChatGPT',
+      tabClaude: 'Claude',
       connectLabel: 'Authorization happens upfront — grab a code on the Connect page, hand it to your AI, and it takes care of the rest:',
       connectSteps: [
         'Sign in on the Connect page to get a one-time auth code',
@@ -42,6 +44,13 @@ const LOCALE = {
         'Type @longbridge in the message box to query market data',
       ],
       chatgptCta: 'Open Longbridge in ChatGPT',
+      claudeLabel: 'Enable Longbridge in Claude Desktop or claude.ai in under a minute:',
+      claudeSteps: [
+        'Open the Longbridge connector in the Claude directory',
+        'Click Connect and authorize your Longbridge account',
+        'Ask Claude for live market data in plain conversation',
+      ],
+      claudeCta: 'Open Longbridge in Claude',
       installLabel: 'Copy and send to any AI — it will walk you through install:',
       installLink: 'View installation guide for each client',
       agentsLabel: 'Supported AI tools',
@@ -144,10 +153,11 @@ const LOCALE = {
       title2: '为您的 AI 解锁市场洞察、深度研究与智能交易',
       desc: 'Claude Code、Codex、Gemini 等 Agent 可通过 Longbridge Skill <a href="https://longbridge.com/en/screener" target="_blank" rel="noreferrer">筛选股票</a>、解读财报、追踪机构动向，并直接下单。',
       chatgptLine:
-        '<a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">ChatGPT</a> 可以直接安装 <a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">Longbridge</a>，并通过 <code>@longbridge</code> 来使用。',
+        '<a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">ChatGPT</a> 与 <a class="skill-chatgpt-link" href="https://claude.ai/directory/connectors/longbridge-mcp">Claude</a> 都能直接安装 Longbridge——在 ChatGPT 中用 <code>@longbridge</code> 调用，在 Claude 中启用连接器即可。',
       tabConnect: 'Connect AI',
       tabPrompt: '复制命令',
       tabChatGPT: 'ChatGPT',
+      tabClaude: 'Claude',
       connectLabel: '授权一步前置——在 Connect 页面拿到授权码，交给 AI，剩下的它来完成：',
       connectSteps: [
         '登录 Connect 页面，获取一次性授权码',
@@ -162,6 +172,13 @@ const LOCALE = {
         '在输入框中输入 @longbridge 开始查询数据',
       ],
       chatgptCta: '在 ChatGPT 中打开 Longbridge',
+      claudeLabel: '在 Claude Desktop 或 claude.ai 中快速启用 Longbridge：',
+      claudeSteps: [
+        '在 Claude 应用目录中打开 Longbridge 连接器',
+        '点击 Connect，并按提示完成 Longbridge 账户授权',
+        '直接向 Claude 提问，即可查询实时市场数据',
+      ],
+      claudeCta: '在 Claude 中打开 Longbridge',
       installLabel: '复制发送给任意 AI——它将引导您完成安装：',
       installLink: '查看各客户端安装指南',
       agentsLabel: '支持的 AI 工具',
@@ -389,10 +406,11 @@ const LOCALE = {
       title2: '為您的 AI 解鎖市場洞察、深度研究與智能交易',
       desc: 'Claude Code、Codex、Gemini 等 Agent 可透過 Longbridge Skill <a href="https://longbridge.com/en/screener" target="_blank" rel="noreferrer">篩選股票</a>、解讀財報、追蹤機構動向，並直接下單。',
       chatgptLine:
-        '<a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">ChatGPT</a> 可以直接安裝 <a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">Longbridge</a>，並透過 <code>@longbridge</code> 來使用。',
+        '<a class="skill-chatgpt-link" href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef">ChatGPT</a> 與 <a class="skill-chatgpt-link" href="https://claude.ai/directory/connectors/longbridge-mcp">Claude</a> 都能直接安裝 Longbridge——在 ChatGPT 中用 <code>@longbridge</code> 調用，在 Claude 中啟用連接器即可。',
       tabConnect: 'Connect AI',
       tabPrompt: '複製命令',
       tabChatGPT: 'ChatGPT',
+      tabClaude: 'Claude',
       connectLabel: '授權一步前置——在 Connect 頁面拿到授權碼，交給 AI，剩下的它來完成：',
       connectSteps: [
         '登入 Connect 頁面，獲取一次性授權碼',
@@ -407,6 +425,13 @@ const LOCALE = {
         '在輸入框中輸入 @longbridge 開始查詢數據',
       ],
       chatgptCta: '在 ChatGPT 中打開 Longbridge',
+      claudeLabel: '在 Claude Desktop 或 claude.ai 中快速啟用 Longbridge：',
+      claudeSteps: [
+        '在 Claude 應用目錄中打開 Longbridge 連接器',
+        '點擊 Connect，並按提示完成 Longbridge 賬戶授權',
+        '直接向 Claude 提問，即可查詢即時市場數據',
+      ],
+      claudeCta: '在 Claude 中打開 Longbridge',
       installLabel: '複製發送給任意 AI——它將引導您完成安裝：',
       installLink: '查看各客戶端安裝指南',
       agentsLabel: '支援的 AI 工具',
@@ -1090,7 +1115,7 @@ const CAP_REFERENCE = [
 const activeCat = ref('All')
 const scenarioIdx = ref(0)
 const activeAgent = ref('OpenClaw')
-const installMode = ref<'connect' | 'prompt' | 'chatgpt'>('connect')
+const installMode = ref<'connect' | 'prompt' | 'chatgpt' | 'claude'>('connect')
 const copied = ref(false)
 const copiedGetStarted = ref(false)
 
@@ -1377,6 +1402,11 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
                 @click="installMode = 'chatgpt'">
                 {{ content.hero.tabChatGPT }}
               </button>
+              <button
+                :class="['skill-hero-seg-btn', installMode === 'claude' && 'is-active']"
+                @click="installMode = 'claude'">
+                {{ content.hero.tabClaude }}
+              </button>
             </div>
 
             <template v-if="installMode === 'connect'">
@@ -1457,7 +1487,7 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
               </a>
             </template>
 
-            <template v-else>
+            <template v-else-if="installMode === 'chatgpt'">
               <div class="skill-hero-install-label">{{ content.hero.chatgptLabel }}</div>
               <div class="skill-hero-connect-card">
                 <div v-for="(step, i) in content.hero.chatgptSteps" :key="i" class="skill-hero-connect-step">
@@ -1479,6 +1509,32 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
                     <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
                   </svg>
                   {{ content.hero.chatgptCta }}
+                </a>
+              </div>
+            </template>
+
+            <template v-else>
+              <div class="skill-hero-install-label">{{ content.hero.claudeLabel }}</div>
+              <div class="skill-hero-connect-card">
+                <div v-for="(step, i) in content.hero.claudeSteps" :key="i" class="skill-hero-connect-step">
+                  <span class="skill-hero-connect-step-num">{{ i + 1 }}</span>
+                  <span>{{ step }}</span>
+                </div>
+                <a class="btn btn-dark" :href="CLAUDE_CONNECTOR_URL" target="_blank" rel="noreferrer">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round">
+                    <path d="M15 3h6v6" />
+                    <path d="M10 14 21 3" />
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                  </svg>
+                  {{ content.hero.claudeCta }}
                 </a>
               </div>
             </template>
@@ -2332,12 +2388,11 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
 .skill-chatgpt-feature {
   position: relative;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+  gap: 8px;
   width: fit-content;
-  max-width: min(640px, 100%);
+  max-width: min(680px, 100%);
   margin: 14px auto 0;
   padding: 10px 14px;
   border: 1px solid #e5e5e5;
@@ -2346,6 +2401,7 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
   color: var(--lb-fg-1);
   font-size: 15px;
   line-height: 1.55;
+  text-align: left;
   overflow: hidden;
 }
 .skill-chatgpt-feature::before {
@@ -2373,9 +2429,11 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
 .skill-chatgpt-feature > * {
   position: relative;
   z-index: 1;
+  min-width: 0;
 }
 .skill-chatgpt-sparkles {
   flex: 0 0 auto;
+  margin-top: 3px;
   color: #f59e0b;
 }
 .skill-chatgpt-feature :deep(.skill-chatgpt-link) {
@@ -2508,9 +2566,10 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
   border-radius: 999px;
   background: var(--lb-bg-2);
   border: 1px solid var(--app-card-stroke);
+  max-width: 100%;
 }
 .skill-hero-seg-btn {
-  padding: 6px 18px;
+  padding: 6px 16px;
   border-radius: 999px;
   font-size: 13px;
   font-weight: 600;
@@ -4101,6 +4160,20 @@ function triggerRipple(event: MouseEvent, el: HTMLElement) {
 @media (max-width: 640px) {
   .skill-hero-install-cmd {
     max-width: 100%;
+  }
+  .skill-hero-seg {
+    width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .skill-hero-seg::-webkit-scrollbar {
+    display: none;
+  }
+  .skill-hero-seg-btn {
+    flex: 0 0 auto;
+    padding: 6px 14px;
+    white-space: nowrap;
   }
   .skill-demo-chat-body {
     overflow-x: auto;


### PR DESCRIPTION
## What changed

**Skill page (`/skill/`)**
- New **Claude** tab in the install segmented control (Connect AI · Copy command · ChatGPT · **Claude**), linking to the Claude connector directory `https://claude.ai/directory/connectors/longbridge-mcp`. Tab bar now scrolls instead of overflowing on mobile.
- Hero callout now covers both channels: "ChatGPT and Claude can install Longbridge directly — use `@longbridge` in ChatGPT, or the connector in Claude." (fixed its layout so the longer sentence wraps cleanly instead of centering raggedly).

**Home page**
- New **"Now available in ChatGPT and Claude"** intro band above the FEATURES section, reusing the exact same `eyebrow + h-section` header style as the other sections, with ChatGPT / Claude logo chips on the right.

All copy synced across **en / zh-CN / zh-HK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)