### PR TITLE
skills: Document the A2A agent chat commands

### DIFF
--- a/skills/longbridge/SKILL.md
+++ b/skills/longbridge/SKILL.md
@@ -139,6 +139,7 @@ Add Longbridge API docs to IDE/RAG       LLMs.txt / Markdown API
 ### AI Integration
 
 - **MCP** — ChatGPT Apps, hosted service, self-hosted server, setup & auth: [references/mcp.md](references/mcp.md)
+- **A2A Agent Chat** — discover and chat with Longbridge AI agents from the CLI (`longbridge agent list` / `longbridge agent chat`); run `longbridge agent --skill` for the complete agent-to-agent workflow document.
 - **LLMs & Markdown** — llms.txt, `open.longbridge.com` doc Markdown, `longbridge.com` live news/quote pages (`.md` suffix + Accept header), Cursor/IDE integration: [references/llm.md](references/llm.md)
 
 Load specific reference files on demand — do not load all at once.

--- a/skills/longbridge/references/cli/overview.md
+++ b/skills/longbridge/references/cli/overview.md
@@ -115,6 +115,28 @@ longbridge filing list TSLA.US
 longbridge filing detail TSLA.US 610186794100660481 --file-index 0
 ```
 
+### A2A agent chat
+
+Chat with Longbridge AI agents (research assistants, screeners, custom
+agents) directly from the CLI:
+
+```bash
+longbridge agent list --format json                 # discover chat agents (--all adds workflow agents)
+longbridge agent chat <UID> "<query>" --format json # returns answer + widgets + references
+longbridge agent chat <UID> <CHAT_UID> <MSG_ID> "<follow-up>"
+longbridge agent continue <UID> <CHAT_UID> <MSG_ID> --answer "…"  # resume interrupted runs
+```
+
+Responses aggregate a server-sent-event stream; runs can take 1–2 minutes.
+Serialize calls — bursts are rejected with rate-limit code 429002. Run
+`longbridge agent --skill` for the full A2A workflow document, and rely on
+`--help` for flag details.
+
+Listing is scoped to workspaces you own, but any published agent is chattable
+by uid, so you can talk to more agents than the command can enumerate. Public
+ones appear under workspace `Public: Longbridge` — currently `chatbot`
+(LongbridgeAI). A uid absent from the list is still worth trying.
+
 ## Extended Hours (Pre/Post Market)
 
 `quote`, `intraday`, `kline`, `kline history` all support extended-hours data. Use `longbridge <command> --help` for exact flags — key points:


### PR DESCRIPTION
The CLI gained a command surface for the AI Agent (A2A) API — workspace and agent discovery, chat with multi-turn follow-ups, and answering an interrupted run. Add it to the capability index and give it a section in the CLI reference.

Both stay high-level per the repo's convention, deferring to `longbridge agent --skill` for the full workflow document and to `--help` for flag detail. The one non-obvious rule is spelled out: listing is scoped to workspaces you own while any published agent is chattable by uid, so a uid absent from the list is still worth trying, and public agents appear under `Public: Longbridge`.

Companion to longbridge/longbridge-terminal's [A2A agent commands PR](https://github.com/longbridge/longbridge-terminal/pull/280); the two need to land together or the skill files describe a CLI that does not match.