### PR TITLE
feat(footer): add AI Integrations column with ChatGPT App and Claude Connector

### DIFF
--- a/docs/.vitepress/theme/components/AppFooter.vue
+++ b/docs/.vitepress/theme/components/AppFooter.vue
@@ -62,9 +62,29 @@ const year = new Date().getFullYear()
         <ul>
           <li><a :href="localePath('/skill')">AI Skill</a></li>
           <li><a :href="localePath('/docs/cli')">CLI</a></li>
-          <li><a :href="localePath('/docs/mcp')">MCP</a></li>
           <li><a :href="localePath('/docs/llm')">LLMs</a></li>
           <li><a href="https://navi-lang.org" target="_blank">Navi</a></li>
+        </ul>
+      </div>
+
+      <!-- AI Integrations -->
+      <div>
+        <h5>{{ t('footer.integrations') }}</h5>
+        <ul>
+          <li><a :href="localePath('/docs/mcp')">MCP</a></li>
+          <li>
+            <a
+              href="https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef"
+              target="_blank"
+              rel="noreferrer"
+              >ChatGPT App</a
+            >
+          </li>
+          <li>
+            <a href="https://claude.ai/directory/connectors/longbridge" target="_blank" rel="noreferrer"
+              >Claude Connector</a
+            >
+          </li>
         </ul>
       </div>
 

--- a/docs/.vitepress/theme/components/HomePage/Footer.vue
+++ b/docs/.vitepress/theme/components/HomePage/Footer.vue
@@ -66,6 +66,8 @@ const leftLinks = computed(() => [
 const rightLinks = computed(() => [
   { href: '/sdk', label: 'SDK' },
   { href: '/docs/mcp', label: 'MCP' },
+  { href: 'https://chatgpt.com/apps/longbridge/asdk_app_6a2baf2fad748191812393c3e00308ef', label: 'ChatGPT App' },
+  { href: 'https://claude.ai/directory/connectors/longbridge', label: 'Claude Connector' },
   { href: '/docs/cli', label: 'CLI' },
   { href: '/docs/llm', label: 'LLM' },
   { href: '/docs/assets', label: t('footer.assets') },

--- a/docs/.vitepress/theme/locales/en.json
+++ b/docs/.vitepress/theme/locales/en.json
@@ -77,6 +77,7 @@
   "footer.tagline": "Real-time market data, trading, and financial intelligence — delivered through AI Skill, CLI, MCP, SDK and OpenAPI for developers worldwide.",
   "footer.status": "All systems operational",
   "footer.products": "Products",
+  "footer.integrations": "AI Integrations",
   "footer.resources": "Resources",
   "footer.company": "Company",
   "footer.legal": "Legal",

--- a/docs/.vitepress/theme/locales/zh-CN.json
+++ b/docs/.vitepress/theme/locales/zh-CN.json
@@ -77,6 +77,7 @@
   "footer.tagline": "为全球开发者提供实时行情、交易与金融智能服务——通过 AI Skill、CLI、MCP、SDK 和 OpenAPI 全面赋能。",
   "footer.status": "所有服务正常运行",
   "footer.products": "产品",
+  "footer.integrations": "AI 集成",
   "footer.resources": "资源",
   "footer.company": "公司",
   "footer.legal": "法律",

--- a/docs/.vitepress/theme/locales/zh-HK.json
+++ b/docs/.vitepress/theme/locales/zh-HK.json
@@ -77,6 +77,7 @@
   "footer.tagline": "為全球開發者提供即時行情、交易與金融智能服務——透過 AI Skill、CLI、MCP、SDK 和 OpenAPI 全面賦能。",
   "footer.status": "所有服務正常運行",
   "footer.products": "產品",
+  "footer.integrations": "AI 整合",
   "footer.resources": "資源",
   "footer.company": "公司",
   "footer.legal": "法律",

--- a/docs/.vitepress/theme/style/app-styles.css
+++ b/docs/.vitepress/theme/style/app-styles.css
@@ -498,13 +498,13 @@ body {
   font-weight: 600;
 }
 
-/* Footer v2 — 5 columns */
+/* Footer v2 — 6 columns */
 .app-footer-inner-v2 {
   max-width: var(--app-max);
   margin: 0 auto;
   display: grid;
-  grid-template-columns: 1.6fr repeat(4, 1fr);
-  gap: 48px;
+  grid-template-columns: 1.6fr repeat(5, 1fr);
+  gap: 40px;
 }
 @media (max-width: 1024px) {
   .app-footer-inner-v2 {


### PR DESCRIPTION
新增页脚 **AI Integrations** 分栏，展示 Longbridge 的三种 AI 接入方式：

- **MCP**（从 Products 栏迁移至此）
- **ChatGPT App** — 链接到 ChatGPT App 商店页
- **Claude Connector** — 链接到 Claude 连接器目录

同时在首页页脚（HomePage/Footer.vue）补充 ChatGPT App 与 Claude Connector 链接。

页脚网格由 5 列扩展为 6 列，三语言（en / zh-CN / zh-HK）文案同步新增 `footer.integrations`。