### PR TITLE
docs: clarify ACP usage and setup

### DIFF
--- a/docs/en/docs/changelog.md
+++ b/docs/en/docs/changelog.md
@@ -19,7 +19,7 @@ sidebar_icon: newspaper
 
 ### CLI v0.27.0
 
-- **New `acp` runtime — bring the Longbridge AI into any editor** — `longbridge acp` turns the market-aware Longbridge AI (live quotes, fundamentals, portfolio insight) into a provider-neutral [Agent Client Protocol](https://agentclientprotocol.com/) (ACP) server, so ACP-native tools like Zed can chat with it out of the box — no custom integration. Ships embedded / stdio sessions and ready-made Codex / Claude adapter presets, while the CLI keeps API / auth ownership
+- **[Use Longbridge AI over ACP](/en/docs/cli/acp)** — The new `longbridge acp` command makes [Longbridge AI](https://longbridge.com/ai) available in compatible client applications for live market data, company analysis, and account position insights
 - **New `agent` commands** — discover and chat with agents on Longbridge AI from the terminal: `agent workspaces`, `agent list`, streaming `agent chat`, `agent continue`, and `agent --skill`
 
 ## 2026-07-20

--- a/docs/en/docs/cli/acp.md
+++ b/docs/en/docs/cli/acp.md
@@ -1,0 +1,84 @@
+---
+title: 'acp'
+sidebar_label: 'ACP agent'
+sidebar_position: 98
+sidebar_icon: bot
+---
+
+# longbridge acp
+
+`longbridge acp` runs [Longbridge AI](https://longbridge.com/ai) as an [Agent Client Protocol](https://agentclientprotocol.com/) (ACP) compatible agent. From any client application that can launch a custom ACP agent, you can talk with Longbridge AI to look up live market data, analyze company fundamentals, and interpret account positions.
+
+## Use cases
+
+- Use Longbridge AI from a preferred AI client without switching applications
+- Ask follow-up questions about markets, companies, and positions without calling and coordinating multiple APIs yourself
+- Resume an earlier session and continue existing research and analysis
+
+## Before you start
+
+Install Longbridge CLI and sign in:
+
+```bash
+longbridge auth login
+```
+
+Verify that the ACP command is available:
+
+```bash
+longbridge acp --help
+```
+
+The ACP agent shares authentication with other CLI commands, so no separate API key configuration is required.
+
+## Configure a client
+
+Add a custom ACP agent in your client with these values:
+
+| Setting | Value |
+| --- | --- |
+| Name | `Longbridge AI` |
+| Command / Executable | `longbridge` |
+| Arguments | `acp` |
+| Environment | Leave empty |
+
+The client starts `longbridge acp` when needed and communicates with the agent over stdin/stdout. Client interfaces and configuration files differ; fields such as `agent_servers` are client conventions, not part of ACP itself.
+
+When choosing a client, confirm that it can add a custom or local ACP agent and lets you set the command and arguments separately. Web and mobile clients that support only remote agents cannot launch `longbridge acp` directly. See the [ACP client directory](https://agentclientprotocol.com/get-started/clients) for the current ecosystem, and check each product's documentation for custom-agent support.
+
+### Zed configuration example
+
+In Zed, open **External Agents** and choose **Add Agent** → **Add Custom Agent**, then configure:
+
+```json
+{
+  "agent_servers": {
+    "Longbridge AI": {
+      "type": "custom",
+      "command": "longbridge",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Save the configuration, start an External Agent thread, and select **Longbridge AI**. See the [Zed External Agents documentation](https://zed.dev/docs/ai/external-agents).
+
+## Sessions
+
+Clients that support the corresponding ACP capabilities can create, list, and resume sessions. Session history is stored locally, so a previous conversation can continue after the agent process restarts.
+
+## Troubleshooting
+
+### `longbridge` command not found
+
+Desktop applications may not inherit your terminal's `PATH`. Replace the command with the full path to the `longbridge` executable. Remote environments and containers require their own Longbridge CLI installation and login.
+
+### Authentication required
+
+Run `longbridge auth login` in the same environment that runs the ACP agent, then reconnect.
+
+### Can I configure it as an MCP server?
+
+No. ACP carries conversations between client applications and agents; MCP provides tools and context to models. `longbridge acp` is an ACP agent, not an MCP server.

--- a/docs/en/docs/cli/release-notes.md
+++ b/docs/en/docs/cli/release-notes.md
@@ -9,7 +9,7 @@ sidebar_icon: newspaper
 
 ### [v0.27.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.27.0)
 
-- **New `acp` runtime — bring Longbridge AI into your editor** — `longbridge acp` exposes the Longbridge AI as a provider-neutral [Agent Client Protocol](https://agentclientprotocol.com/) (ACP) server via the new `longbridge-ai-acp` crate, so any ACP client (Zed today, more to come) gets a market-aware agent — live quotes, fundamentals, portfolio insight — with zero custom integration. Ships embedded and stdio sessions plus ready-made Codex and Claude adapter presets, and the CLI keeps API / auth ownership so your keys never leave it
+- **[Use Longbridge AI over ACP](/en/docs/cli/acp)** — The new `longbridge acp` command runs [Longbridge AI](https://longbridge.com/ai) as an [Agent Client Protocol](https://agentclientprotocol.com/) (ACP) compatible agent. You can now look up live market data, analyze company fundamentals, and interpret account positions from compatible client applications; see the ACP guide for setup
 - **New `agent` commands for Longbridge AI** — `agent workspaces` lists AI workspaces; `agent list` discovers chat-capable agents (`--workspace`, `--name`; `--all` includes workflow agents); `agent chat chatbot "…"` holds a conversation over SSE (`--stream` for live tokens — the public `chatbot` agent is usable by any account), with `agent chat chatbot <CHAT_UID> <MSG_ID> "…"` for multi-turn follow-ups; `agent continue chatbot <CHAT_UID> <MSG_ID>` resumes an interrupted run (`--answer` / `--answers-json`); and `agent --skill` prints the agent skill doc for AI harnesses
 
 ### [v0.26.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.26.0)

--- a/docs/zh-CN/docs/changelog.md
+++ b/docs/zh-CN/docs/changelog.md
@@ -19,7 +19,7 @@ sidebar_icon: newspaper
 
 ### CLI v0.27.0
 
-- **新增 `acp` 运行时——把 Longbridge AI 接进任意编辑器** — `longbridge acp` 将「懂行情」的 Longbridge AI（实时行情、基本面、组合洞察）变成 provider-neutral 的 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）服务，Zed 等 ACP 原生工具开箱即可与它对话，无需任何自建集成；支持内嵌 / stdio 会话，内置 Codex / Claude 适配器预设，同时 API / 鉴权仍由 CLI 掌管
+- **[通过 ACP 使用 Longbridge AI](/zh-CN/docs/cli/acp)** — 新增 `longbridge acp` 命令，现在可以在支持 ACP 的客户端应用中使用 [Longbridge AI](https://longbridge.com/ai) 查询实时行情、分析公司基本面和解读账户持仓
 - **新增 `agent` 命令** — 在终端发现并与 Longbridge AI 对话：`agent workspaces`、`agent list`、流式 `agent chat`、`agent continue` 与 `agent --skill`
 
 ## 2026-07-20

--- a/docs/zh-CN/docs/cli/acp.md
+++ b/docs/zh-CN/docs/cli/acp.md
@@ -1,0 +1,84 @@
+---
+title: 'acp'
+sidebar_label: 'ACP Agent'
+sidebar_position: 98
+sidebar_icon: bot
+---
+
+# longbridge acp
+
+`longbridge acp` 将 [Longbridge AI](https://longbridge.com/ai) 作为兼容 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）的 Agent 运行。你可以从任何支持启动自定义 ACP Agent 的客户端应用中与 Longbridge AI 对话，查询实时行情、分析公司基本面、解读账户持仓。
+
+## 使用场景
+
+- 在常用 AI 客户端中直接使用 Longbridge AI，无需切换应用
+- 围绕市场、公司和持仓连续追问，无需自行调用和组合多个 API
+- 恢复之前的会话，继续已有的研究与分析
+
+## 使用前准备
+
+安装 Longbridge CLI 并登录：
+
+```bash
+longbridge auth login
+```
+
+确认 ACP 命令可用：
+
+```bash
+longbridge acp --help
+```
+
+ACP Agent 与其他 CLI 命令共用登录状态，无需单独配置 API 密钥。
+
+## 配置客户端
+
+在客户端中添加一个自定义 ACP Agent，并填写：
+
+| 配置项 | 值 |
+| --- | --- |
+| 名称 | `Longbridge AI` |
+| 命令 / Executable | `longbridge` |
+| 参数 / Arguments | `acp` |
+| 环境变量 | 留空 |
+
+客户端会在需要时启动 `longbridge acp`，并通过 stdin/stdout 与 Agent 通信。不同客户端的界面和配置文件格式可能不同；`agent_servers` 等字段是客户端自己的约定，并不是 ACP 协议的一部分。
+
+选择客户端时，请确认其支持添加“自定义 Agent”或“本地 ACP Agent”，并允许分别设置命令和参数。仅支持远程 Agent 的 Web 或移动客户端不能直接启动 `longbridge acp`。可从 [ACP 客户端目录](https://agentclientprotocol.com/get-started/clients)了解当前的客户端生态，具体支持情况以各产品文档为准。
+
+### Zed 配置示例
+
+在 Zed 的 **External Agents** 中选择 **Add Agent** → **Add Custom Agent**，然后配置：
+
+```json
+{
+  "agent_servers": {
+    "Longbridge AI": {
+      "type": "custom",
+      "command": "longbridge",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+保存后新建 External Agent 对话并选择 **Longbridge AI**。详见 [Zed External Agents 文档](https://zed.dev/docs/ai/external-agents)。
+
+## 会话
+
+支持相应 ACP 能力的客户端可以创建、列出和恢复会话。会话历史保留在本地，因此 Agent 进程重启后仍可继续之前的对话。
+
+## 常见问题
+
+### 找不到 `longbridge` 命令
+
+从桌面启动的应用可能不会继承终端的 `PATH`。请将“命令”改为 `longbridge` 可执行文件的完整路径。远程环境或容器需要单独安装并登录 Longbridge CLI。
+
+### 提示未登录
+
+在运行 ACP Agent 的同一环境中执行 `longbridge auth login`，然后重新连接。
+
+### 可以配置成 MCP Server 吗？
+
+不可以。ACP 用于客户端应用与 Agent 之间的会话通信；MCP 用于向模型提供工具和上下文。`longbridge acp` 是 ACP Agent，不是 MCP Server。

--- a/docs/zh-CN/docs/cli/release-notes.md
+++ b/docs/zh-CN/docs/cli/release-notes.md
@@ -9,7 +9,7 @@ sidebar_icon: newspaper
 
 ### [v0.27.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.27.0)
 
-- **新增 `acp` 运行时——把 Longbridge AI 接入你的编辑器** — `longbridge acp` 通过新的 `longbridge-ai-acp` crate 将 Longbridge AI 暴露为 provider-neutral 的 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）服务：任何 ACP 客户端（当下是 Zed，未来更多）都能零集成接入一个「懂市场」的 Agent——实时行情、基本面、组合洞察一应俱全；支持内嵌与 stdio 会话，内置 Codex 与 Claude 适配器预设，API / 鉴权始终由 CLI 掌管、密钥不外泄
+- **[通过 ACP 使用 Longbridge AI](/zh-CN/docs/cli/acp)** — 新增 `longbridge acp` 命令，将 [Longbridge AI](https://longbridge.com/ai) 作为兼容 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）的 Agent 运行。现在可以在支持 ACP 的客户端应用中查询实时行情、分析公司基本面和解读账户持仓；配置方法请参阅 ACP 使用指南
 - **新增 Longbridge AI `agent` 命令** — `agent workspaces` 列出 AI 工作区；`agent list` 发现可对话的 Agent（`--workspace`、`--name`；`--all` 含工作流 Agent）；`agent chat chatbot "…"` 通过 SSE 进行对话（`--stream` 实时输出——公开的 `chatbot` Agent 任何账户可用），多轮追问用 `agent chat chatbot <CHAT_UID> <MSG_ID> "…"`；`agent continue chatbot <CHAT_UID> <MSG_ID>` 恢复被中断的运行（`--answer` / `--answers-json`）；`agent --skill` 输出面向 AI harness 的 agent skill 文档
 
 ### [v0.26.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.26.0)

--- a/docs/zh-HK/docs/changelog.md
+++ b/docs/zh-HK/docs/changelog.md
@@ -19,7 +19,7 @@ sidebar_icon: newspaper
 
 ### CLI v0.27.0
 
-- **新增 `acp` 運行時——把 Longbridge AI 接進任意編輯器** — `longbridge acp` 將「懂行情」的 Longbridge AI（實時行情、基本面、組合洞察）變成 provider-neutral 的 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）服務，Zed 等 ACP 原生工具開箱即可與它對話，無需任何自建集成；支持內嵌 / stdio 會話，內置 Codex / Claude 適配器預設，同時 API / 鑑權仍由 CLI 掌管
+- **[通過 ACP 使用 Longbridge AI](/zh-HK/docs/cli/acp)** — 新增 `longbridge acp` 命令，現在可以在支持 ACP 的客戶端應用中使用 [Longbridge AI](https://longbridge.com/ai) 查詢實時行情、分析公司基本面和解讀賬戶持倉
 - **新增 `agent` 命令** — 在終端發現並與 Longbridge AI 對話：`agent workspaces`、`agent list`、流式 `agent chat`、`agent continue` 與 `agent --skill`
 
 ## 2026-07-20

--- a/docs/zh-HK/docs/cli/acp.md
+++ b/docs/zh-HK/docs/cli/acp.md
@@ -1,0 +1,84 @@
+---
+title: 'acp'
+sidebar_label: 'ACP Agent'
+sidebar_position: 98
+sidebar_icon: bot
+---
+
+# longbridge acp
+
+`longbridge acp` 將 [Longbridge AI](https://longbridge.com/ai) 作為兼容 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）的 Agent 運行。你可以從任何支持啟動自定義 ACP Agent 的客戶端應用中與 Longbridge AI 對話，查詢實時行情、分析公司基本面、解讀賬戶持倉。
+
+## 使用場景
+
+- 在常用 AI 客戶端中直接使用 Longbridge AI，無需切換應用
+- 圍繞市場、公司和持倉連續追問，無需自行調用和組合多個 API
+- 恢復之前的會話，繼續已有的研究與分析
+
+## 使用前準備
+
+安裝 Longbridge CLI 並登錄：
+
+```bash
+longbridge auth login
+```
+
+確認 ACP 命令可用：
+
+```bash
+longbridge acp --help
+```
+
+ACP Agent 與其他 CLI 命令共用登錄狀態，無需單獨配置 API 密鑰。
+
+## 配置客戶端
+
+在客戶端中添加一個自定義 ACP Agent，並填寫：
+
+| 配置項 | 值 |
+| --- | --- |
+| 名稱 | `Longbridge AI` |
+| 命令 / Executable | `longbridge` |
+| 參數 / Arguments | `acp` |
+| 環境變量 | 留空 |
+
+客戶端會在需要時啟動 `longbridge acp`，並通過 stdin/stdout 與 Agent 通信。不同客戶端的介面和配置文件格式可能不同；`agent_servers` 等字段是客戶端自己的約定，並不是 ACP 協議的一部分。
+
+選擇客戶端時，請確認其支持添加「自定義 Agent」或「本地 ACP Agent」，並允許分別設置命令和參數。僅支持遠程 Agent 的 Web 或移動客戶端不能直接啟動 `longbridge acp`。可從 [ACP 客戶端目錄](https://agentclientprotocol.com/get-started/clients)了解當前的客戶端生態，具體支持情況以各產品文檔為準。
+
+### Zed 配置示例
+
+在 Zed 的 **External Agents** 中選擇 **Add Agent** → **Add Custom Agent**，然後配置：
+
+```json
+{
+  "agent_servers": {
+    "Longbridge AI": {
+      "type": "custom",
+      "command": "longbridge",
+      "args": ["acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+保存後新建 External Agent 對話並選擇 **Longbridge AI**。詳見 [Zed External Agents 文檔](https://zed.dev/docs/ai/external-agents)。
+
+## 會話
+
+支持相應 ACP 能力的客戶端可以創建、列出和恢復會話。會話歷史保留在本地，因此 Agent 進程重啟後仍可繼續之前的對話。
+
+## 常見問題
+
+### 找不到 `longbridge` 命令
+
+從桌面啟動的應用可能不會繼承終端的 `PATH`。請將「命令」改為 `longbridge` 可執行文件的完整路徑。遠程環境或容器需要單獨安裝並登錄 Longbridge CLI。
+
+### 提示未登錄
+
+在運行 ACP Agent 的同一環境中執行 `longbridge auth login`，然後重新連接。
+
+### 可以配置成 MCP Server 嗎？
+
+不可以。ACP 用於客戶端應用與 Agent 之間的會話通信；MCP 用於向模型提供工具和上下文。`longbridge acp` 是 ACP Agent，不是 MCP Server。

--- a/docs/zh-HK/docs/cli/release-notes.md
+++ b/docs/zh-HK/docs/cli/release-notes.md
@@ -9,7 +9,7 @@ sidebar_icon: newspaper
 
 ### [v0.27.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.27.0)
 
-- **新增 `acp` 運行時——把 Longbridge AI 接入你的編輯器** — `longbridge acp` 通過新的 `longbridge-ai-acp` crate 將 Longbridge AI 暴露為 provider-neutral 的 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）服務：任何 ACP 客戶端（當下是 Zed，未來更多）都能零集成接入一個「懂市場」的 Agent——實時行情、基本面、組合洞察一應俱全；支持內嵌與 stdio 會話，內置 Codex 與 Claude 適配器預設，API / 鑑權始終由 CLI 掌管、密鑰不外洩
+- **[通過 ACP 使用 Longbridge AI](/zh-HK/docs/cli/acp)** — 新增 `longbridge acp` 命令，將 [Longbridge AI](https://longbridge.com/ai) 作為兼容 [Agent Client Protocol](https://agentclientprotocol.com/)（ACP）的 Agent 運行。現在可以在支持 ACP 的客戶端應用中查詢實時行情、分析公司基本面和解讀賬戶持倉；配置方法請參閱 ACP 使用指南
 - **新增 Longbridge AI `agent` 命令** — `agent workspaces` 列出 AI 工作區；`agent list` 發現可對話的 Agent（`--workspace`、`--name`；`--all` 含工作流 Agent）；`agent chat chatbot "…"` 通過 SSE 進行對話（`--stream` 實時輸出——公開的 `chatbot` Agent 任何賬戶可用），多輪追問用 `agent chat chatbot <CHAT_UID> <MSG_ID> "…"`；`agent continue chatbot <CHAT_UID> <MSG_ID>` 恢復被中斷的運行（`--answer` / `--answers-json`）；`agent --skill` 輸出面向 AI harness 的 agent skill 文檔
 
 ### [v0.26.0](https://github.com/longbridge/longbridge-terminal/releases/tag/v0.26.0)


### PR DESCRIPTION
## Summary

- rewrite the CLI v0.27.0 ACP release note around user-facing purpose and investment scenarios
- add English, Simplified Chinese, and Traditional Chinese `longbridge acp` guides
- document generic ACP client configuration and keep Zed as the sole product-specific example
- link Longbridge AI and the release notes to the new setup guide

## Test Plan

- `git diff --check`
- `npm run build:release`