### PR TITLE
docs(trade): add multi-leg option order docs

### DIFF
--- a/docs/en/docs/trade/definition.md
+++ b/docs/en/docs/trade/definition.md
@@ -98,6 +98,19 @@ sidebar_position: 2
 | remark         | string | remark message                                                                                                           |
 | last_share         | string | last share |
 | last_price         | string | last price |
+| multi_leg          | object | Multi-leg strategy information. Only pushed for multi-leg option combination orders                                   |
+| ∟ strategy         | string | Multi-leg strategy<br/><br/>**Enum Value**<br/>`0` - CoveredCall (Covered stock)<br />`1` - CoveredPut (Covered stock)<br />`2` - VerticalCallSpread (Vertical spread)<br />`3` - VerticalPutSpread (Vertical spread)<br />`4` - Collar<br />`5` - Straddle<br />`6` - Strangle |
+| ∟ strategy_name    | string | strategy name                                                                                                         |
+| ∟ multileg_id      | string | multi-leg combination ID                                                                                              |
+| ∟ code             | string | multi-leg combination code                                                                                            |
+| ∟ legs             | object[] | legs of the combination order                                                                                       |
+| ∟∟ symbol          | string | option symbol, use `ticker.region` format                                                                             |
+| ∟∟ side            | string | order side<br/><br/>**Enum Value**<br/>`Buy`<br />`Sell`                                                              |
+| ∟∟ position        | string | position direction<br/><br/>**Enum Value**<br/>`LONG`<br />`SHORT`                                                    |
+| ∟∟ ratio_quantity  | string | leg ratio quantity                                                                                                    |
+| ∟∟ strike_price    | string | strike price                                                                                                          |
+| ∟∟ expire_date     | string | option expiry date, format: `YYYYMMDD`                                                                                |
+| ∟∟ contract_direction | string | contract type<br/><br/>**Enum Value**<br/>`C` - Call<br />`P` - Put                                                |
 
 ### example
 
@@ -129,7 +142,33 @@ sidebar_position: 2
 		"account_no": "HK123445",
 		"last_share": "100",
 		"last_price": "234",
-		"remark": "abc"
+		"remark": "abc",
+		"multi_leg": {
+			"strategy": "2",
+			"strategy_name": "Vertical spread",
+			"multileg_id": "Spread_QQQ20260731C764/767",
+			"code": "QQQ 260731 764/767 Vertical spread",
+			"legs": [
+				{
+					"symbol": "QQQ260731C764000.US",
+					"side": "Buy",
+					"position": "LONG",
+					"ratio_quantity": "1",
+					"strike_price": "764",
+					"expire_date": "20260731",
+					"contract_direction": "C"
+				},
+				{
+					"symbol": "QQQ260731C767000.US",
+					"side": "Sell",
+					"position": "SHORT",
+					"ratio_quantity": "1",
+					"strike_price": "767",
+					"expire_date": "20260731",
+					"contract_direction": "C"
+				}
+			]
+		}
 	}
 }
 ```

--- a/docs/en/docs/trade/order/history_orders.md
+++ b/docs/en/docs/trade/order/history_orders.md
@@ -308,7 +308,35 @@ func main() {
             "activate_rth": "RTH_ONLY",
             "submit_price": ""
           }
-        ]
+        ],
+        "multi_leg": {
+          "strategy": "2",
+          "strategy_name": "Vertical spread",
+          "multileg_id": "Spread_QQQ20260731C764/767",
+          "code": "QQQ 260731 764/767 Vertical spread",
+          "legs": [
+            {
+              "symbol": "QQQ260731C764000.US",
+              "side": "Buy",
+              "position": "LONG",
+              "ratio_quantity": "1",
+              "strike_price": "764",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            },
+            {
+              "symbol": "QQQ260731C767000.US",
+              "side": "Sell",
+              "position": "SHORT",
+              "ratio_quantity": "1",
+              "strike_price": "767",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            }
+          ]
+        }
       }
     ]
   }
@@ -387,3 +415,17 @@ func main() {
 | ∟∟ activate_order_type      | string   | true     | Order type submitted after triggering, e.g. `LIT` (limit-if-touched) or `MIT` (market-if-touched) |
 | ∟∟ activate_rth             | string   | true     | Whether the order submitted after triggering allows pre/post market trading    |
 | ∟∟ submit_price             | string   | true     | Submitted price                    |
+| ∟ multi_leg                 | object   | false    | Multi-leg strategy information. Only returned for multi-leg option combination orders; otherwise not returned. |
+| ∟∟ strategy                 | string   | false    | Multi-leg strategy<br/><br/> **Enum Value:**<br/> `0` - CoveredCall (Covered stock)<br/> `1` - CoveredPut (Covered stock)<br/> `2` - VerticalCallSpread (Vertical spread)<br/> `3` - VerticalPutSpread (Vertical spread)<br/> `4` - Collar<br/> `5` - Straddle<br/> `6` - Strangle |
+| ∟∟ strategy_name            | string   | false    | Strategy name |
+| ∟∟ multileg_id              | string   | false    | Multi-leg combination ID |
+| ∟∟ code                     | string   | false    | Multi-leg combination code |
+| ∟∟ legs                     | object[] | false    | Legs of the combination order |
+| ∟∟∟ symbol                  | string   | false    | Option symbol, use `ticker.region` format, example: `QQQ260731C764000.US` |
+| ∟∟∟ side                    | string   | false    | Order Side<br/><br/> **Enum Value:**<br/> `Buy`<br/> `Sell` |
+| ∟∟∟ position                | string   | false    | Position direction<br/><br/> **Enum Value:**<br/> `LONG`<br/> `SHORT` |
+| ∟∟∟ ratio_quantity          | string   | false    | Leg ratio quantity |
+| ∟∟∟ strike_price            | string   | false    | Strike price |
+| ∟∟∟ expire_date             | string   | false    | Option expiry date, format: `YYYYMMDD` |
+| ∟∟∟ contract_direction      | string   | false    | Contract type<br/><br/> **Enum Value:**<br/> `C` - Call<br/> `P` - Put |
+| ∟∟∟ contract_size           | string   | false    | Contract size |

--- a/docs/en/docs/trade/order/order_detail.md
+++ b/docs/en/docs/trade/order/order_detail.md
@@ -331,7 +331,35 @@ func main() {
         "activate_rth": "RTH_ONLY",
         "submit_price": ""
       }
-    ]
+    ],
+    "multi_leg": {
+      "strategy": "2",
+      "strategy_name": "Vertical spread",
+      "multileg_id": "Spread_QQQ20260731C764/767",
+      "code": "QQQ 260731 764/767 Vertical spread",
+      "legs": [
+        {
+          "symbol": "QQQ260731C764000.US",
+          "side": "Buy",
+          "position": "LONG",
+          "ratio_quantity": "1",
+          "strike_price": "764",
+          "expire_date": "20260731",
+          "contract_direction": "C",
+          "contract_size": ""
+        },
+        {
+          "symbol": "QQQ260731C767000.US",
+          "side": "Sell",
+          "position": "SHORT",
+          "ratio_quantity": "1",
+          "strike_price": "767",
+          "expire_date": "20260731",
+          "contract_direction": "C",
+          "contract_size": ""
+        }
+      ]
+    }
   }
 }
 ```
@@ -434,3 +462,17 @@ Order Information
 | ∟∟ activate_order_type     | string   | true     | Order type submitted after triggering, e.g. `LIT` (limit-if-touched) or `MIT` (market-if-touched) |
 | ∟∟ activate_rth            | string   | true     | Whether the order submitted after triggering allows pre/post market trading |
 | ∟∟ submit_price            | string   | true     | Submitted price |
+| multi_leg                  | object   | false    | Multi-leg strategy information. Only returned for multi-leg option combination orders; otherwise not returned. |
+| ∟ strategy                 | string   | false    | Multi-leg strategy<br/><br/> **Enum Value:**<br/> `0` - CoveredCall (Covered stock)<br/> `1` - CoveredPut (Covered stock)<br/> `2` - VerticalCallSpread (Vertical spread)<br/> `3` - VerticalPutSpread (Vertical spread)<br/> `4` - Collar<br/> `5` - Straddle<br/> `6` - Strangle |
+| ∟ strategy_name            | string   | false    | Strategy name |
+| ∟ multileg_id              | string   | false    | Multi-leg combination ID |
+| ∟ code                     | string   | false    | Multi-leg combination code |
+| ∟ legs                     | object[] | false    | Legs of the combination order |
+| ∟∟ symbol                  | string   | false    | Option symbol, use `ticker.region` format, example: `QQQ260731C764000.US` |
+| ∟∟ side                    | string   | false    | Order Side<br/><br/> **Enum Value:**<br/> `Buy`<br/> `Sell` |
+| ∟∟ position                | string   | false    | Position direction<br/><br/> **Enum Value:**<br/> `LONG`<br/> `SHORT` |
+| ∟∟ ratio_quantity          | string   | false    | Leg ratio quantity |
+| ∟∟ strike_price            | string   | false    | Strike price |
+| ∟∟ expire_date             | string   | false    | Option expiry date, format: `YYYYMMDD` |
+| ∟∟ contract_direction      | string   | false    | Contract type<br/><br/> **Enum Value:**<br/> `C` - Call<br/> `P` - Put |
+| ∟∟ contract_size           | string   | false    | Contract size |

--- a/docs/en/docs/trade/order/submit_multileg.md
+++ b/docs/en/docs/trade/order/submit_multileg.md
@@ -1,0 +1,71 @@
+---
+slug: submit_multileg
+sidebar_position: 8
+title: Submit Multi-leg Order
+language_tabs: false
+toc_footers: []
+includes: []
+search: true
+highlight_theme: ''
+headingLevel: 2
+---
+
+This API is used to submit a multi-leg option combination order (such as vertical spreads, straddles, strangles, collars, etc.). All legs are submitted together as a single strategy order.
+
+<SDKLinks module="trade" klass="TradeContext" method="submit_multileg" />
+
+## Request
+
+<table className="http-basic">
+<tbody>
+<tr><td className="http-basic-key">HTTP Method</td><td>POST</td></tr>
+<tr><td className="http-basic-key">HTTP URL</td><td>/v1/trade/order/multileg </td></tr>
+</tbody>
+</table>
+
+### Parameters
+
+> Content-Type: application/json; charset=utf-8
+
+| Name               | Type     | Required | Description                                                                                                                                                        |
+| ------------------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| side               | string   | YES      | Order Side<br/><br/> **Enum Value:**<br/> `Buy`<br/> `Sell`                                                                                                        |
+| order_type         | string   | YES      | [Order Type](../trade-definition#ordertype)                                                                                                                        |
+| submitted_price    | string   | NO       | Submitted price, example: `1.5`<br/><br/> Required for limit order types such as `LO`                                                                              |
+| submitted_quantity | string   | YES      | Submitted quantity (number of combinations), example: `1`                                                                                                          |
+| strategy           | string   | YES      | Multi-leg strategy<br/><br/> **Enum Value:**<br/> `CoveredCall` - Covered stock<br/> `CoveredPut` - Covered stock<br/> `VerticalCallSpread` - Vertical spread<br/> `VerticalPutSpread` - Vertical spread<br/> `Collar` - Collar<br/> `Straddle` - Straddle<br/> `Strangle` - Strangle |
+| legs               | object[] | YES      | Legs of the combination order                                                                                                                                      |
+| ∟ symbol           | string   | YES      | Option symbol, use `ticker.region` format, example: `QQQ260731C764000.US`                                                                                          |
+| ∟ ratio_quantity   | string   | YES      | Leg ratio quantity, example: `1`                                                                                                                                   |
+| remark             | string   | NO       | Remark (Maximum 255 characters)                                                                                                                                    |
+| client_request_id  | string   | NO       | Client request ID, used for idempotency (Maximum 64 characters)                                                                                                    |
+
+### Request Example
+
+## Response
+
+### Response Headers
+
+- Content-Type: application/json
+
+### Response Example
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "order_id": 683615454870679600
+  }
+}
+```
+
+### Response Status
+
+| Status | Description                                                   | Schema |
+| ------ | ------------------------------------------------------------- | ------ |
+| 200    | The submission was successful and the order was commissioned. | None   |
+| 400    | The submit was rejected with an incorrect request parameter.  | None   |
+
+<aside className="success">
+</aside>

--- a/docs/en/docs/trade/order/today_orders.md
+++ b/docs/en/docs/trade/order/today_orders.md
@@ -301,7 +301,35 @@ func main() {
             "activate_rth": "RTH_ONLY",
             "submit_price": ""
           }
-        ]
+        ],
+        "multi_leg": {
+          "strategy": "2",
+          "strategy_name": "Vertical spread",
+          "multileg_id": "Spread_QQQ20260731C764/767",
+          "code": "QQQ 260731 764/767 Vertical spread",
+          "legs": [
+            {
+              "symbol": "QQQ260731C764000.US",
+              "side": "Buy",
+              "position": "LONG",
+              "ratio_quantity": "1",
+              "strike_price": "764",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            },
+            {
+              "symbol": "QQQ260731C767000.US",
+              "side": "Sell",
+              "position": "SHORT",
+              "ratio_quantity": "1",
+              "strike_price": "767",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            }
+          ]
+        }
       }
     ]
   }
@@ -379,3 +407,17 @@ func main() {
 | ∟∟ activate_order_type      | string   | true     | Order type submitted after triggering, e.g. `LIT` (limit-if-touched) or `MIT` (market-if-touched) |
 | ∟∟ activate_rth             | string   | true     | Whether the order submitted after triggering allows pre/post market trading |
 | ∟∟ submit_price             | string   | true     | Submitted price |
+| ∟ multi_leg                 | object   | false    | Multi-leg strategy information. Only returned for multi-leg option combination orders; otherwise not returned. |
+| ∟∟ strategy                 | string   | false    | Multi-leg strategy<br/><br/> **Enum Value:**<br/> `0` - CoveredCall (Covered stock)<br/> `1` - CoveredPut (Covered stock)<br/> `2` - VerticalCallSpread (Vertical spread)<br/> `3` - VerticalPutSpread (Vertical spread)<br/> `4` - Collar<br/> `5` - Straddle<br/> `6` - Strangle |
+| ∟∟ strategy_name            | string   | false    | Strategy name |
+| ∟∟ multileg_id              | string   | false    | Multi-leg combination ID |
+| ∟∟ code                     | string   | false    | Multi-leg combination code |
+| ∟∟ legs                     | object[] | false    | Legs of the combination order |
+| ∟∟∟ symbol                  | string   | false    | Option symbol, use `ticker.region` format, example: `QQQ260731C764000.US` |
+| ∟∟∟ side                    | string   | false    | Order Side<br/><br/> **Enum Value:**<br/> `Buy`<br/> `Sell` |
+| ∟∟∟ position                | string   | false    | Position direction<br/><br/> **Enum Value:**<br/> `LONG`<br/> `SHORT` |
+| ∟∟∟ ratio_quantity          | string   | false    | Leg ratio quantity |
+| ∟∟∟ strike_price            | string   | false    | Strike price |
+| ∟∟∟ expire_date             | string   | false    | Option expiry date, format: `YYYYMMDD` |
+| ∟∟∟ contract_direction      | string   | false    | Contract type<br/><br/> **Enum Value:**<br/> `C` - Call<br/> `P` - Put |
+| ∟∟∟ contract_size           | string   | false    | Contract size |

--- a/docs/en/docs/trade/overview.md
+++ b/docs/en/docs/trade/overview.md
@@ -16,8 +16,11 @@ sidebar_position: 1
     </thead>
     <tbody>
     <tr>
-        <td rowspan="8">Trade</td>
+        <td rowspan="9">Trade</td>
         <td><a href="./order/submit">Submit Order</a></td>
+    </tr>
+    <tr>
+        <td><a href="./order/submit_multileg">Submit Multi-leg Order</a></td>
     </tr>
     <tr>
         <td><a href="./order/replace">Replace Order</a></td>

--- a/docs/zh-CN/docs/trade/definition.md
+++ b/docs/zh-CN/docs/trade/definition.md
@@ -98,6 +98,19 @@ sidebar_position: 2
 | remark         | string | 备注                                                                                                                           |
 | last_share         | string | 最新成交数量																																													 |
 | last_price         | string | 最新成交价格																																													 |
+| multi_leg          | object | 多腿策略信息，仅多腿期权组合订单推送                                                                                                     |
+| ∟ strategy         | string | 多腿策略<br/><br/>**可选值**<br/>`0` - CoveredCall（股票担保）<br />`1` - CoveredPut（股票担保）<br />`2` - VerticalCallSpread（垂直策略）<br />`3` - VerticalPutSpread（垂直策略）<br />`4` - Collar（领式策略）<br />`5` - Straddle（跨式策略）<br />`6` - Strangle（宽跨式策略） |
+| ∟ strategy_name    | string | 策略名称                                                                                                                             |
+| ∟ multileg_id      | string | 多腿组合 ID                                                                                                                          |
+| ∟ code             | string | 多腿组合代码                                                                                                                          |
+| ∟ legs             | object[] | 组合订单的各腿                                                                                                                      |
+| ∟∟ symbol          | string | 期权 symbol，使用 `ticker.region` 格式                                                                                                |
+| ∟∟ side            | string | 买卖方向<br/><br/>**可选值**<br/>`Buy`<br />`Sell`                                                                                    |
+| ∟∟ position        | string | 持仓方向<br/><br/>**可选值**<br/>`LONG`<br />`SHORT`                                                                                  |
+| ∟∟ ratio_quantity  | string | 该腿比例数量                                                                                                                          |
+| ∟∟ strike_price    | string | 行权价                                                                                                                               |
+| ∟∟ expire_date     | string | 期权到期日，格式：`YYYYMMDD`                                                                                                          |
+| ∟∟ contract_direction | string | 合约类型<br/><br/>**可选值**<br/>`C` - 看涨（Call）<br />`P` - 看跌（Put）                                                          |
 
 ### 示例
 
@@ -129,7 +142,33 @@ sidebar_position: 2
 		"account_no": "HK123445",
 		"last_share": "100",
 		"last_price": "234",
-		"remark": "abc"
+		"remark": "abc",
+		"multi_leg": {
+			"strategy": "2",
+			"strategy_name": "垂直策略",
+			"multileg_id": "Spread_QQQ20260731C764/767",
+			"code": "QQQ 260731 764/767 垂直策略",
+			"legs": [
+				{
+					"symbol": "QQQ260731C764000.US",
+					"side": "Buy",
+					"position": "LONG",
+					"ratio_quantity": "1",
+					"strike_price": "764",
+					"expire_date": "20260731",
+					"contract_direction": "C"
+				},
+				{
+					"symbol": "QQQ260731C767000.US",
+					"side": "Sell",
+					"position": "SHORT",
+					"ratio_quantity": "1",
+					"strike_price": "767",
+					"expire_date": "20260731",
+					"contract_direction": "C"
+				}
+			]
+		}
 	}
 }
 ```

--- a/docs/zh-CN/docs/trade/order/history_orders.md
+++ b/docs/zh-CN/docs/trade/order/history_orders.md
@@ -307,7 +307,35 @@ func main() {
             "activate_rth": "RTH_ONLY",
             "submit_price": ""
           }
-        ]
+        ],
+        "multi_leg": {
+          "strategy": "2",
+          "strategy_name": "垂直策略",
+          "multileg_id": "Spread_QQQ20260731C764/767",
+          "code": "QQQ 260731 764/767 垂直策略",
+          "legs": [
+            {
+              "symbol": "QQQ260731C764000.US",
+              "side": "Buy",
+              "position": "LONG",
+              "ratio_quantity": "1",
+              "strike_price": "764",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            },
+            {
+              "symbol": "QQQ260731C767000.US",
+              "side": "Sell",
+              "position": "SHORT",
+              "ratio_quantity": "1",
+              "strike_price": "767",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            }
+          ]
+        }
       }
     ]
   }
@@ -386,3 +414,17 @@ func main() {
 | ∟∟ activate_order_type      | string   | true     | 触发后提交的订单类型，例如 `LIT`（限价单）或 `MIT`（市价单） |
 | ∟∟ activate_rth             | string   | true     | 触发后提交订单是否允许盘前盘后。|
 | ∟∟ submit_price             | string   | true     | 委托价格 |
+| ∟ multi_leg                 | object   | false    | 多腿策略信息，仅多腿期权组合订单返回，非组合订单不返回。 |
+| ∟∟ strategy                 | string   | false    | 多腿策略<br/><br/> **可选值：**<br/> `0` - CoveredCall（股票担保）<br/> `1` - CoveredPut（股票担保）<br/> `2` - VerticalCallSpread（垂直策略）<br/> `3` - VerticalPutSpread（垂直策略）<br/> `4` - Collar（领式策略）<br/> `5` - Straddle（跨式策略）<br/> `6` - Strangle（宽跨式策略） |
+| ∟∟ strategy_name            | string   | false    | 策略名称 |
+| ∟∟ multileg_id              | string   | false    | 多腿组合 ID |
+| ∟∟ code                     | string   | false    | 多腿组合代码 |
+| ∟∟ legs                     | object[] | false    | 组合订单的各腿 |
+| ∟∟∟ symbol                  | string   | false    | 期权 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US` |
+| ∟∟∟ side                    | string   | false    | 买卖方向<br/><br/> **可选值：**<br/> `Buy`<br/> `Sell` |
+| ∟∟∟ position                | string   | false    | 持仓方向<br/><br/> **可选值：**<br/> `LONG`<br/> `SHORT` |
+| ∟∟∟ ratio_quantity          | string   | false    | 该腿比例数量 |
+| ∟∟∟ strike_price            | string   | false    | 行权价 |
+| ∟∟∟ expire_date             | string   | false    | 期权到期日，格式：`YYYYMMDD` |
+| ∟∟∟ contract_direction      | string   | false    | 合约类型<br/><br/> **可选值：**<br/> `C` - 看涨（Call）<br/> `P` - 看跌（Put） |
+| ∟∟∟ contract_size           | string   | false    | 合约乘数 |

--- a/docs/zh-CN/docs/trade/order/order_detail.md
+++ b/docs/zh-CN/docs/trade/order/order_detail.md
@@ -330,7 +330,35 @@ func main() {
         "activate_rth": "RTH_ONLY",
         "submit_price": ""
       }
-    ]
+    ],
+    "multi_leg": {
+      "strategy": "2",
+      "strategy_name": "垂直策略",
+      "multileg_id": "Spread_QQQ20260731C764/767",
+      "code": "QQQ 260731 764/767 垂直策略",
+      "legs": [
+        {
+          "symbol": "QQQ260731C764000.US",
+          "side": "Buy",
+          "position": "LONG",
+          "ratio_quantity": "1",
+          "strike_price": "764",
+          "expire_date": "20260731",
+          "contract_direction": "C",
+          "contract_size": ""
+        },
+        {
+          "symbol": "QQQ260731C767000.US",
+          "side": "Sell",
+          "position": "SHORT",
+          "ratio_quantity": "1",
+          "strike_price": "767",
+          "expire_date": "20260731",
+          "contract_direction": "C",
+          "contract_size": ""
+        }
+      ]
+    }
   }
 }
 ```
@@ -433,3 +461,17 @@ func main() {
 | ∟∟ activate_order_type     | string   | true     | 触发后提交的订单类型，例如 `LIT`（限价单）或 `MIT`（市价单） |
 | ∟∟ activate_rth            | string   | true     | 触发后提交订单是否允许盘前盘后。 |
 | ∟∟ submit_price            | string   | true     | 委托价格 |
+| multi_leg                  | object   | false    | 多腿策略信息，仅多腿期权组合订单返回，非组合订单不返回。 |
+| ∟ strategy                 | string   | false    | 多腿策略<br/><br/> **可选值：**<br/> `0` - CoveredCall（股票担保）<br/> `1` - CoveredPut（股票担保）<br/> `2` - VerticalCallSpread（垂直策略）<br/> `3` - VerticalPutSpread（垂直策略）<br/> `4` - Collar（领式策略）<br/> `5` - Straddle（跨式策略）<br/> `6` - Strangle（宽跨式策略） |
+| ∟ strategy_name            | string   | false    | 策略名称 |
+| ∟ multileg_id              | string   | false    | 多腿组合 ID |
+| ∟ code                     | string   | false    | 多腿组合代码 |
+| ∟ legs                     | object[] | false    | 组合订单的各腿 |
+| ∟∟ symbol                  | string   | false    | 期权 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US` |
+| ∟∟ side                    | string   | false    | 买卖方向<br/><br/> **可选值：**<br/> `Buy`<br/> `Sell` |
+| ∟∟ position                | string   | false    | 持仓方向<br/><br/> **可选值：**<br/> `LONG`<br/> `SHORT` |
+| ∟∟ ratio_quantity          | string   | false    | 该腿比例数量 |
+| ∟∟ strike_price            | string   | false    | 行权价 |
+| ∟∟ expire_date             | string   | false    | 期权到期日，格式：`YYYYMMDD` |
+| ∟∟ contract_direction      | string   | false    | 合约类型<br/><br/> **可选值：**<br/> `C` - 看涨（Call）<br/> `P` - 看跌（Put） |
+| ∟∟ contract_size           | string   | false    | 合约乘数 |

--- a/docs/zh-CN/docs/trade/order/submit_multileg.md
+++ b/docs/zh-CN/docs/trade/order/submit_multileg.md
@@ -1,0 +1,71 @@
+---
+slug: submit_multileg
+sidebar_position: 8
+title: 多腿期权下单
+language_tabs: false
+toc_footers: []
+includes: []
+search: true
+highlight_theme: ''
+headingLevel: 2
+---
+
+该接口用于提交多腿期权组合订单（如垂直价差、跨式、宽跨式、领口等）。各腿作为一个策略订单一起提交。
+
+<SDKLinks module="trade" klass="TradeContext" method="submit_multileg" />
+
+## Request
+
+<table className="http-basic">
+<tbody>
+<tr><td className="http-basic-key">HTTP Method</td><td>POST</td></tr>
+<tr><td className="http-basic-key">HTTP URL</td><td>/v1/trade/order/multileg </td></tr>
+</tbody>
+</table>
+
+### Parameters
+
+> Content-Type: application/json; charset=utf-8
+
+| Name               | Type     | Required | Description                                                                                                                                                        |
+| ------------------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| side               | string   | YES      | 买卖方向<br/><br/> **可选值：**<br/> `Buy`<br/> `Sell`                                                                                                             |
+| order_type         | string   | YES      | [订单类型](../trade-definition#ordertype)                                                                                                                          |
+| submitted_price    | string   | NO       | 下单价格，例如：`1.5`<br/><br/> `LO` 等限价类型订单必填                                                                                                             |
+| submitted_quantity | string   | YES      | 下单数量（组合数量），例如：`1`                                                                                                                                     |
+| strategy           | string   | YES      | 多腿策略<br/><br/> **可选值：**<br/> `CoveredCall` - 股票担保<br/> `CoveredPut` - 股票担保<br/> `VerticalCallSpread` - 垂直策略<br/> `VerticalPutSpread` - 垂直策略<br/> `Collar` - 领式策略<br/> `Straddle` - 跨式策略<br/> `Strangle` - 宽跨式策略 |
+| legs               | object[] | YES      | 组合订单的各腿                                                                                                                                                      |
+| ∟ symbol           | string   | YES      | 期权 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US`                                                                                                |
+| ∟ ratio_quantity   | string   | YES      | 该腿比例数量，例如：`1`                                                                                                                                             |
+| remark             | string   | NO       | 备注（最多 255 字符）                                                                                                                                               |
+| client_request_id  | string   | NO       | 客户端请求 ID，用于幂等（最多 64 字符）                                                                                                                             |
+
+### Request Example
+
+## Response
+
+### Response Headers
+
+- Content-Type: application/json
+
+### Response Example
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "order_id": 683615454870679600
+  }
+}
+```
+
+### Response Status
+
+| Status | Description            | Schema |
+| ------ | ---------------------- | ------ |
+| 200    | 提交成功，订单已委托     | None   |
+| 400    | 提交被拒绝，请求参数有误 | None   |
+
+<aside className="success">
+</aside>

--- a/docs/zh-CN/docs/trade/order/today_orders.md
+++ b/docs/zh-CN/docs/trade/order/today_orders.md
@@ -300,7 +300,35 @@ func main() {
             "activate_rth": "RTH_ONLY",
             "submit_price": ""
           }
-        ]
+        ],
+        "multi_leg": {
+          "strategy": "2",
+          "strategy_name": "垂直策略",
+          "multileg_id": "Spread_QQQ20260731C764/767",
+          "code": "QQQ 260731 764/767 垂直策略",
+          "legs": [
+            {
+              "symbol": "QQQ260731C764000.US",
+              "side": "Buy",
+              "position": "LONG",
+              "ratio_quantity": "1",
+              "strike_price": "764",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            },
+            {
+              "symbol": "QQQ260731C767000.US",
+              "side": "Sell",
+              "position": "SHORT",
+              "ratio_quantity": "1",
+              "strike_price": "767",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            }
+          ]
+        }
       }
     ]
   }
@@ -378,3 +406,17 @@ func main() {
 | ∟∟ activate_order_type      | string   | true     | 触发后提交的订单类型，例如 `LIT`（限价单）或 `MIT`（市价单） |
 | ∟∟ activate_rth             | string   | true     | 触发后提交订单是否允许盘前盘后。|
 | ∟∟ submit_price             | string   | true     | 委托价格 |
+| ∟ multi_leg                 | object   | false    | 多腿策略信息，仅多腿期权组合订单返回，非组合订单不返回。 |
+| ∟∟ strategy                 | string   | false    | 多腿策略<br/><br/> **可选值：**<br/> `0` - CoveredCall（股票担保）<br/> `1` - CoveredPut（股票担保）<br/> `2` - VerticalCallSpread（垂直策略）<br/> `3` - VerticalPutSpread（垂直策略）<br/> `4` - Collar（领式策略）<br/> `5` - Straddle（跨式策略）<br/> `6` - Strangle（宽跨式策略） |
+| ∟∟ strategy_name            | string   | false    | 策略名称 |
+| ∟∟ multileg_id              | string   | false    | 多腿组合 ID |
+| ∟∟ code                     | string   | false    | 多腿组合代码 |
+| ∟∟ legs                     | object[] | false    | 组合订单的各腿 |
+| ∟∟∟ symbol                  | string   | false    | 期权 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US` |
+| ∟∟∟ side                    | string   | false    | 买卖方向<br/><br/> **可选值：**<br/> `Buy`<br/> `Sell` |
+| ∟∟∟ position                | string   | false    | 持仓方向<br/><br/> **可选值：**<br/> `LONG`<br/> `SHORT` |
+| ∟∟∟ ratio_quantity          | string   | false    | 该腿比例数量 |
+| ∟∟∟ strike_price            | string   | false    | 行权价 |
+| ∟∟∟ expire_date             | string   | false    | 期权到期日，格式：`YYYYMMDD` |
+| ∟∟∟ contract_direction      | string   | false    | 合约类型<br/><br/> **可选值：**<br/> `C` - 看涨（Call）<br/> `P` - 看跌（Put） |
+| ∟∟∟ contract_size           | string   | false    | 合约乘数 |

--- a/docs/zh-CN/docs/trade/overview.md
+++ b/docs/zh-CN/docs/trade/overview.md
@@ -17,8 +17,11 @@ sidebar_position: 1
     </thead>
     <tbody>
     <tr>
-        <td rowspan="8">交易</td>
+        <td rowspan="9">交易</td>
         <td><a href="./order/submit">委托下单</a></td>
+    </tr>
+    <tr>
+        <td><a href="./order/submit_multileg">多腿期权下单</a></td>
     </tr>
     <tr>
         <td><a href="./order/replace">改单</a></td>

--- a/docs/zh-HK/docs/trade/definition.md
+++ b/docs/zh-HK/docs/trade/definition.md
@@ -98,6 +98,19 @@ sidebar_position: 2
 | remark         | string | 備注																																													 |
 | last_share         | string | 最新成交數量																																													 |
 | last_price         | string | 最新成交價格																																													 |
+| multi_leg          | object | 多腿策略信息，僅多腿期權組合訂單推送                                                                                                     |
+| ∟ strategy         | string | 多腿策略<br/><br/>**可選值**<br/>`0` - CoveredCall（股票擔保）<br />`1` - CoveredPut（股票擔保）<br />`2` - VerticalCallSpread（跨價期權）<br />`3` - VerticalPutSpread（跨價期權）<br />`4` - Collar（領式策略）<br />`5` - Straddle（馬鞍式策略）<br />`6` - Strangle（勒束式策略） |
+| ∟ strategy_name    | string | 策略名稱                                                                                                                             |
+| ∟ multileg_id      | string | 多腿組合 ID                                                                                                                          |
+| ∟ code             | string | 多腿組合代碼                                                                                                                          |
+| ∟ legs             | object[] | 組合訂單的各腿                                                                                                                      |
+| ∟∟ symbol          | string | 期權 symbol，使用 `ticker.region` 格式                                                                                                |
+| ∟∟ side            | string | 買賣方向<br/><br/>**可選值**<br/>`Buy`<br />`Sell`                                                                                    |
+| ∟∟ position        | string | 持倉方向<br/><br/>**可選值**<br/>`LONG`<br />`SHORT`                                                                                  |
+| ∟∟ ratio_quantity  | string | 該腿比例數量                                                                                                                          |
+| ∟∟ strike_price    | string | 行權價                                                                                                                               |
+| ∟∟ expire_date     | string | 期權到期日，格式：`YYYYMMDD`                                                                                                          |
+| ∟∟ contract_direction | string | 合約類型<br/><br/>**可選值**<br/>`C` - 看漲（Call）<br />`P` - 看跌（Put）                                                          |
 	
 ### 示例
 
@@ -129,7 +142,33 @@ sidebar_position: 2
 		"account_no": "HK123445",
 		"last_share": "100",
 		"last_price": "234",
-		"remark": "abc"
+		"remark": "abc",
+		"multi_leg": {
+			"strategy": "2",
+			"strategy_name": "跨價期權",
+			"multileg_id": "Spread_QQQ20260731C764/767",
+			"code": "QQQ 260731 764/767 跨價期權",
+			"legs": [
+				{
+					"symbol": "QQQ260731C764000.US",
+					"side": "Buy",
+					"position": "LONG",
+					"ratio_quantity": "1",
+					"strike_price": "764",
+					"expire_date": "20260731",
+					"contract_direction": "C"
+				},
+				{
+					"symbol": "QQQ260731C767000.US",
+					"side": "Sell",
+					"position": "SHORT",
+					"ratio_quantity": "1",
+					"strike_price": "767",
+					"expire_date": "20260731",
+					"contract_direction": "C"
+				}
+			]
+		}
 	}
 }
 ```

--- a/docs/zh-HK/docs/trade/order/history_orders.md
+++ b/docs/zh-HK/docs/trade/order/history_orders.md
@@ -307,7 +307,35 @@ func main() {
             "activate_rth": "RTH_ONLY",
             "submit_price": ""
           }
-        ]
+        ],
+        "multi_leg": {
+          "strategy": "2",
+          "strategy_name": "跨價期權",
+          "multileg_id": "Spread_QQQ20260731C764/767",
+          "code": "QQQ 260731 764/767 跨價期權",
+          "legs": [
+            {
+              "symbol": "QQQ260731C764000.US",
+              "side": "Buy",
+              "position": "LONG",
+              "ratio_quantity": "1",
+              "strike_price": "764",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            },
+            {
+              "symbol": "QQQ260731C767000.US",
+              "side": "Sell",
+              "position": "SHORT",
+              "ratio_quantity": "1",
+              "strike_price": "767",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            }
+          ]
+        }
       }
     ]
   }
@@ -386,3 +414,17 @@ func main() {
 | ∟∟ activate_order_type      | string   | true     | 觸發後提交的訂單類型，例如 `LIT`（限價單）或 `MIT`（市價單） |
 | ∟∟ activate_rth             | string   | true     | 觸發後提交訂單是否允許盤前盤後。|
 | ∟∟ submit_price             | string   | true     | 委託價格 |
+| ∟ multi_leg                 | object   | false    | 多腿策略信息，僅多腿期權組合訂單返回，非組合訂單不返回。 |
+| ∟∟ strategy                 | string   | false    | 多腿策略<br/><br/> **可選值：**<br/> `0` - CoveredCall（股票擔保）<br/> `1` - CoveredPut（股票擔保）<br/> `2` - VerticalCallSpread（跨價期權）<br/> `3` - VerticalPutSpread（跨價期權）<br/> `4` - Collar（領式策略）<br/> `5` - Straddle（馬鞍式策略）<br/> `6` - Strangle（勒束式策略） |
+| ∟∟ strategy_name            | string   | false    | 策略名稱 |
+| ∟∟ multileg_id              | string   | false    | 多腿組合 ID |
+| ∟∟ code                     | string   | false    | 多腿組合代碼 |
+| ∟∟ legs                     | object[] | false    | 組合訂單的各腿 |
+| ∟∟∟ symbol                  | string   | false    | 期權 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US` |
+| ∟∟∟ side                    | string   | false    | 買賣方向<br/><br/> **可選值：**<br/> `Buy`<br/> `Sell` |
+| ∟∟∟ position                | string   | false    | 持倉方向<br/><br/> **可選值：**<br/> `LONG`<br/> `SHORT` |
+| ∟∟∟ ratio_quantity          | string   | false    | 該腿比例數量 |
+| ∟∟∟ strike_price            | string   | false    | 行權價 |
+| ∟∟∟ expire_date             | string   | false    | 期權到期日，格式：`YYYYMMDD` |
+| ∟∟∟ contract_direction      | string   | false    | 合約類型<br/><br/> **可選值：**<br/> `C` - 看漲（Call）<br/> `P` - 看跌（Put） |
+| ∟∟∟ contract_size           | string   | false    | 合約乘數 |

--- a/docs/zh-HK/docs/trade/order/order_detail.md
+++ b/docs/zh-HK/docs/trade/order/order_detail.md
@@ -330,7 +330,35 @@ func main() {
         "activate_rth": "RTH_ONLY",
         "submit_price": ""
       }
-    ]
+    ],
+    "multi_leg": {
+      "strategy": "2",
+      "strategy_name": "跨價期權",
+      "multileg_id": "Spread_QQQ20260731C764/767",
+      "code": "QQQ 260731 764/767 跨價期權",
+      "legs": [
+        {
+          "symbol": "QQQ260731C764000.US",
+          "side": "Buy",
+          "position": "LONG",
+          "ratio_quantity": "1",
+          "strike_price": "764",
+          "expire_date": "20260731",
+          "contract_direction": "C",
+          "contract_size": ""
+        },
+        {
+          "symbol": "QQQ260731C767000.US",
+          "side": "Sell",
+          "position": "SHORT",
+          "ratio_quantity": "1",
+          "strike_price": "767",
+          "expire_date": "20260731",
+          "contract_direction": "C",
+          "contract_size": ""
+        }
+      ]
+    }
   }
 }
 ```
@@ -433,3 +461,17 @@ func main() {
 | ∟∟ activate_order_type     | string   | true     | 觸發後提交的訂單類型，例如 `LIT`（限價單）或 `MIT`（市價單） |
 | ∟∟ activate_rth            | string   | true     | 觸發後提交訂單是否允許盤前盤後。 |
 | ∟∟ submit_price            | string   | true     | 委託價格 |
+| multi_leg                  | object   | false    | 多腿策略信息，僅多腿期權組合訂單返回，非組合訂單不返回。 |
+| ∟ strategy                 | string   | false    | 多腿策略<br/><br/> **可選值：**<br/> `0` - CoveredCall（股票擔保）<br/> `1` - CoveredPut（股票擔保）<br/> `2` - VerticalCallSpread（跨價期權）<br/> `3` - VerticalPutSpread（跨價期權）<br/> `4` - Collar（領式策略）<br/> `5` - Straddle（馬鞍式策略）<br/> `6` - Strangle（勒束式策略） |
+| ∟ strategy_name            | string   | false    | 策略名稱 |
+| ∟ multileg_id              | string   | false    | 多腿組合 ID |
+| ∟ code                     | string   | false    | 多腿組合代碼 |
+| ∟ legs                     | object[] | false    | 組合訂單的各腿 |
+| ∟∟ symbol                  | string   | false    | 期權 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US` |
+| ∟∟ side                    | string   | false    | 買賣方向<br/><br/> **可選值：**<br/> `Buy`<br/> `Sell` |
+| ∟∟ position                | string   | false    | 持倉方向<br/><br/> **可選值：**<br/> `LONG`<br/> `SHORT` |
+| ∟∟ ratio_quantity          | string   | false    | 該腿比例數量 |
+| ∟∟ strike_price            | string   | false    | 行權價 |
+| ∟∟ expire_date             | string   | false    | 期權到期日，格式：`YYYYMMDD` |
+| ∟∟ contract_direction      | string   | false    | 合約類型<br/><br/> **可選值：**<br/> `C` - 看漲（Call）<br/> `P` - 看跌（Put） |
+| ∟∟ contract_size           | string   | false    | 合約乘數 |

--- a/docs/zh-HK/docs/trade/order/submit_multileg.md
+++ b/docs/zh-HK/docs/trade/order/submit_multileg.md
@@ -1,0 +1,71 @@
+---
+slug: submit_multileg
+sidebar_position: 8
+title: 多腿期權下單
+language_tabs: false
+toc_footers: []
+includes: []
+search: true
+highlight_theme: ''
+headingLevel: 2
+---
+
+該接口用於提交多腿期權組合訂單（如垂直價差、跨式、寬跨式、領口等）。各腿作為一個策略訂單一起提交。
+
+<SDKLinks module="trade" klass="TradeContext" method="submit_multileg" />
+
+## Request
+
+<table className="http-basic">
+<tbody>
+<tr><td className="http-basic-key">HTTP Method</td><td>POST</td></tr>
+<tr><td className="http-basic-key">HTTP URL</td><td>/v1/trade/order/multileg </td></tr>
+</tbody>
+</table>
+
+### Parameters
+
+> Content-Type: application/json; charset=utf-8
+
+| Name               | Type     | Required | Description                                                                                                                                                        |
+| ------------------ | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| side               | string   | YES      | 買賣方向<br/><br/> **可選值：**<br/> `Buy`<br/> `Sell`                                                                                                             |
+| order_type         | string   | YES      | [訂單類型](../trade-definition#ordertype)                                                                                                                          |
+| submitted_price    | string   | NO       | 下單價格，例如：`1.5`<br/><br/> `LO` 等限價類型訂單必填                                                                                                             |
+| submitted_quantity | string   | YES      | 下單數量（組合數量），例如：`1`                                                                                                                                     |
+| strategy           | string   | YES      | 多腿策略<br/><br/> **可選值：**<br/> `CoveredCall` - 股票擔保<br/> `CoveredPut` - 股票擔保<br/> `VerticalCallSpread` - 跨價期權<br/> `VerticalPutSpread` - 跨價期權<br/> `Collar` - 領式策略<br/> `Straddle` - 馬鞍式策略<br/> `Strangle` - 勒束式策略 |
+| legs               | object[] | YES      | 組合訂單的各腿                                                                                                                                                      |
+| ∟ symbol           | string   | YES      | 期權 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US`                                                                                                |
+| ∟ ratio_quantity   | string   | YES      | 該腿比例數量，例如：`1`                                                                                                                                             |
+| remark             | string   | NO       | 備註（最多 255 字符）                                                                                                                                               |
+| client_request_id  | string   | NO       | 客戶端請求 ID，用於冪等（最多 64 字符）                                                                                                                             |
+
+### Request Example
+
+## Response
+
+### Response Headers
+
+- Content-Type: application/json
+
+### Response Example
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": {
+    "order_id": 683615454870679600
+  }
+}
+```
+
+### Response Status
+
+| Status | Description            | Schema |
+| ------ | ---------------------- | ------ |
+| 200    | 提交成功，訂單已委託     | None   |
+| 400    | 提交被拒絕，請求參數有誤 | None   |
+
+<aside className="success">
+</aside>

--- a/docs/zh-HK/docs/trade/order/today_orders.md
+++ b/docs/zh-HK/docs/trade/order/today_orders.md
@@ -300,7 +300,35 @@ func main() {
             "activate_rth": "RTH_ONLY",
             "submit_price": ""
           }
-        ]
+        ],
+        "multi_leg": {
+          "strategy": "2",
+          "strategy_name": "跨價期權",
+          "multileg_id": "Spread_QQQ20260731C764/767",
+          "code": "QQQ 260731 764/767 跨價期權",
+          "legs": [
+            {
+              "symbol": "QQQ260731C764000.US",
+              "side": "Buy",
+              "position": "LONG",
+              "ratio_quantity": "1",
+              "strike_price": "764",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            },
+            {
+              "symbol": "QQQ260731C767000.US",
+              "side": "Sell",
+              "position": "SHORT",
+              "ratio_quantity": "1",
+              "strike_price": "767",
+              "expire_date": "20260731",
+              "contract_direction": "C",
+              "contract_size": ""
+            }
+          ]
+        }
       }
     ]
   }
@@ -378,3 +406,17 @@ func main() {
 | ∟∟ activate_order_type      | string   | true     | 觸發後提交的訂單類型，例如 `LIT`（限價單）或 `MIT`（市價單） |
 | ∟∟ activate_rth             | string   | true     | 觸發後提交訂單是否允許盤前盤後。|
 | ∟∟ submit_price             | string   | true     | 委託價格 |
+| ∟ multi_leg                 | object   | false    | 多腿策略信息，僅多腿期權組合訂單返回，非組合訂單不返回。 |
+| ∟∟ strategy                 | string   | false    | 多腿策略<br/><br/> **可選值：**<br/> `0` - CoveredCall（股票擔保）<br/> `1` - CoveredPut（股票擔保）<br/> `2` - VerticalCallSpread（跨價期權）<br/> `3` - VerticalPutSpread（跨價期權）<br/> `4` - Collar（領式策略）<br/> `5` - Straddle（馬鞍式策略）<br/> `6` - Strangle（勒束式策略） |
+| ∟∟ strategy_name            | string   | false    | 策略名稱 |
+| ∟∟ multileg_id              | string   | false    | 多腿組合 ID |
+| ∟∟ code                     | string   | false    | 多腿組合代碼 |
+| ∟∟ legs                     | object[] | false    | 組合訂單的各腿 |
+| ∟∟∟ symbol                  | string   | false    | 期權 symbol，使用 `ticker.region` 格式，例如：`QQQ260731C764000.US` |
+| ∟∟∟ side                    | string   | false    | 買賣方向<br/><br/> **可選值：**<br/> `Buy`<br/> `Sell` |
+| ∟∟∟ position                | string   | false    | 持倉方向<br/><br/> **可選值：**<br/> `LONG`<br/> `SHORT` |
+| ∟∟∟ ratio_quantity          | string   | false    | 該腿比例數量 |
+| ∟∟∟ strike_price            | string   | false    | 行權價 |
+| ∟∟∟ expire_date             | string   | false    | 期權到期日，格式：`YYYYMMDD` |
+| ∟∟∟ contract_direction      | string   | false    | 合約類型<br/><br/> **可選值：**<br/> `C` - 看漲（Call）<br/> `P` - 看跌（Put） |
+| ∟∟∟ contract_size           | string   | false    | 合約乘數 |

--- a/docs/zh-HK/docs/trade/overview.md
+++ b/docs/zh-HK/docs/trade/overview.md
@@ -17,8 +17,11 @@ sidebar_position: 1
     </thead>
     <tbody>
     <tr>
-        <td rowspan="8">交易</td>
+        <td rowspan="9">交易</td>
         <td><a href="./order/submit">委托下單</a></td>
+    </tr>
+    <tr>
+        <td><a href="./order/submit_multileg">多腿期權下單</a></td>
     </tr>
     <tr>
         <td><a href="./order/replace">改單</a></td>


### PR DESCRIPTION
1.新增多腿期权下单接口，订单查询/详情与 WebSocket 推送补充 multi_leg 字段。