### PR TITLE
docs(trade): remove contract_size from multi_leg legs

### DIFF
--- a/docs/en/docs/trade/order/history_orders.md
+++ b/docs/en/docs/trade/order/history_orders.md
@@ -322,8 +322,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "764",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             },
             {
               "symbol": "QQQ260731C767000.US",
@@ -332,8 +331,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "767",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             }
           ]
         }
@@ -428,4 +426,3 @@ func main() {
 | ∟∟∟ strike_price            | string   | false    | Strike price |
 | ∟∟∟ expire_date             | string   | false    | Option expiry date, format: `YYYYMMDD` |
 | ∟∟∟ contract_direction      | string   | false    | Contract type<br/><br/> **Enum Value:**<br/> `C` - Call<br/> `P` - Put |
-| ∟∟∟ contract_size           | string   | false    | Contract size |

--- a/docs/en/docs/trade/order/order_detail.md
+++ b/docs/en/docs/trade/order/order_detail.md
@@ -345,8 +345,7 @@ func main() {
           "ratio_quantity": "1",
           "strike_price": "764",
           "expire_date": "20260731",
-          "contract_direction": "C",
-          "contract_size": ""
+          "contract_direction": "C"
         },
         {
           "symbol": "QQQ260731C767000.US",
@@ -355,8 +354,7 @@ func main() {
           "ratio_quantity": "1",
           "strike_price": "767",
           "expire_date": "20260731",
-          "contract_direction": "C",
-          "contract_size": ""
+          "contract_direction": "C"
         }
       ]
     }
@@ -475,4 +473,3 @@ Order Information
 | ∟∟ strike_price            | string   | false    | Strike price |
 | ∟∟ expire_date             | string   | false    | Option expiry date, format: `YYYYMMDD` |
 | ∟∟ contract_direction      | string   | false    | Contract type<br/><br/> **Enum Value:**<br/> `C` - Call<br/> `P` - Put |
-| ∟∟ contract_size           | string   | false    | Contract size |

--- a/docs/en/docs/trade/order/today_orders.md
+++ b/docs/en/docs/trade/order/today_orders.md
@@ -315,8 +315,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "764",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             },
             {
               "symbol": "QQQ260731C767000.US",
@@ -325,8 +324,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "767",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             }
           ]
         }
@@ -420,4 +418,3 @@ func main() {
 | ∟∟∟ strike_price            | string   | false    | Strike price |
 | ∟∟∟ expire_date             | string   | false    | Option expiry date, format: `YYYYMMDD` |
 | ∟∟∟ contract_direction      | string   | false    | Contract type<br/><br/> **Enum Value:**<br/> `C` - Call<br/> `P` - Put |
-| ∟∟∟ contract_size           | string   | false    | Contract size |

--- a/docs/zh-CN/docs/trade/order/history_orders.md
+++ b/docs/zh-CN/docs/trade/order/history_orders.md
@@ -321,8 +321,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "764",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             },
             {
               "symbol": "QQQ260731C767000.US",
@@ -331,8 +330,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "767",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             }
           ]
         }
@@ -427,4 +425,3 @@ func main() {
 | ∟∟∟ strike_price            | string   | false    | 行权价 |
 | ∟∟∟ expire_date             | string   | false    | 期权到期日，格式：`YYYYMMDD` |
 | ∟∟∟ contract_direction      | string   | false    | 合约类型<br/><br/> **可选值：**<br/> `C` - 看涨（Call）<br/> `P` - 看跌（Put） |
-| ∟∟∟ contract_size           | string   | false    | 合约乘数 |

--- a/docs/zh-CN/docs/trade/order/order_detail.md
+++ b/docs/zh-CN/docs/trade/order/order_detail.md
@@ -344,8 +344,7 @@ func main() {
           "ratio_quantity": "1",
           "strike_price": "764",
           "expire_date": "20260731",
-          "contract_direction": "C",
-          "contract_size": ""
+          "contract_direction": "C"
         },
         {
           "symbol": "QQQ260731C767000.US",
@@ -354,8 +353,7 @@ func main() {
           "ratio_quantity": "1",
           "strike_price": "767",
           "expire_date": "20260731",
-          "contract_direction": "C",
-          "contract_size": ""
+          "contract_direction": "C"
         }
       ]
     }
@@ -474,4 +472,3 @@ func main() {
 | ∟∟ strike_price            | string   | false    | 行权价 |
 | ∟∟ expire_date             | string   | false    | 期权到期日，格式：`YYYYMMDD` |
 | ∟∟ contract_direction      | string   | false    | 合约类型<br/><br/> **可选值：**<br/> `C` - 看涨（Call）<br/> `P` - 看跌（Put） |
-| ∟∟ contract_size           | string   | false    | 合约乘数 |

--- a/docs/zh-CN/docs/trade/order/today_orders.md
+++ b/docs/zh-CN/docs/trade/order/today_orders.md
@@ -314,8 +314,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "764",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             },
             {
               "symbol": "QQQ260731C767000.US",
@@ -324,8 +323,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "767",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             }
           ]
         }
@@ -419,4 +417,3 @@ func main() {
 | ∟∟∟ strike_price            | string   | false    | 行权价 |
 | ∟∟∟ expire_date             | string   | false    | 期权到期日，格式：`YYYYMMDD` |
 | ∟∟∟ contract_direction      | string   | false    | 合约类型<br/><br/> **可选值：**<br/> `C` - 看涨（Call）<br/> `P` - 看跌（Put） |
-| ∟∟∟ contract_size           | string   | false    | 合约乘数 |

--- a/docs/zh-HK/docs/trade/order/history_orders.md
+++ b/docs/zh-HK/docs/trade/order/history_orders.md
@@ -321,8 +321,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "764",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             },
             {
               "symbol": "QQQ260731C767000.US",
@@ -331,8 +330,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "767",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             }
           ]
         }
@@ -427,4 +425,3 @@ func main() {
 | ∟∟∟ strike_price            | string   | false    | 行權價 |
 | ∟∟∟ expire_date             | string   | false    | 期權到期日，格式：`YYYYMMDD` |
 | ∟∟∟ contract_direction      | string   | false    | 合約類型<br/><br/> **可選值：**<br/> `C` - 看漲（Call）<br/> `P` - 看跌（Put） |
-| ∟∟∟ contract_size           | string   | false    | 合約乘數 |

--- a/docs/zh-HK/docs/trade/order/order_detail.md
+++ b/docs/zh-HK/docs/trade/order/order_detail.md
@@ -344,8 +344,7 @@ func main() {
           "ratio_quantity": "1",
           "strike_price": "764",
           "expire_date": "20260731",
-          "contract_direction": "C",
-          "contract_size": ""
+          "contract_direction": "C"
         },
         {
           "symbol": "QQQ260731C767000.US",
@@ -354,8 +353,7 @@ func main() {
           "ratio_quantity": "1",
           "strike_price": "767",
           "expire_date": "20260731",
-          "contract_direction": "C",
-          "contract_size": ""
+          "contract_direction": "C"
         }
       ]
     }
@@ -474,4 +472,3 @@ func main() {
 | ∟∟ strike_price            | string   | false    | 行權價 |
 | ∟∟ expire_date             | string   | false    | 期權到期日，格式：`YYYYMMDD` |
 | ∟∟ contract_direction      | string   | false    | 合約類型<br/><br/> **可選值：**<br/> `C` - 看漲（Call）<br/> `P` - 看跌（Put） |
-| ∟∟ contract_size           | string   | false    | 合約乘數 |

--- a/docs/zh-HK/docs/trade/order/today_orders.md
+++ b/docs/zh-HK/docs/trade/order/today_orders.md
@@ -314,8 +314,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "764",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             },
             {
               "symbol": "QQQ260731C767000.US",
@@ -324,8 +323,7 @@ func main() {
               "ratio_quantity": "1",
               "strike_price": "767",
               "expire_date": "20260731",
-              "contract_direction": "C",
-              "contract_size": ""
+              "contract_direction": "C"
             }
           ]
         }
@@ -419,4 +417,3 @@ func main() {
 | ∟∟∟ strike_price            | string   | false    | 行權價 |
 | ∟∟∟ expire_date             | string   | false    | 期權到期日，格式：`YYYYMMDD` |
 | ∟∟∟ contract_direction      | string   | false    | 合約類型<br/><br/> **可選值：**<br/> `C` - 看漲（Call）<br/> `P` - 看跌（Put） |
-| ∟∟∟ contract_size           | string   | false    | 合約乘數 |


### PR DESCRIPTION
1.订单详情/当日订单/历史订单的多腿 legs 移除 contract_size 字段说明与示例，