### PR TITLE
docs: extend agent auth code validity from 5 to 10 minutes

### DIFF
--- a/docs/en/docs/agent-auth.md
+++ b/docs/en/docs/agent-auth.md
@@ -34,7 +34,7 @@ For a desktop client that fully supports the browser OAuth flow, the standard [M
 4. **Generate the code** — the page produces a short auth code and a ready-to-paste instruction text.
 5. **Paste it to your AI agent** — copy the instruction text and send it to your assistant. The agent redeems the code using one of the methods below.
 
-The code is valid for **5 minutes** and can be used **once**.
+The code is valid for **10 minutes** and can be used **once**.
 
 ## Redeem via CLI
 
@@ -68,7 +68,7 @@ Replace `<token>` with the token returned by `authenticate`. Note this points at
 ## Security
 
 - **Scope is pre-selected on the web** — the code can only grant the permissions you chose on the authorization page; an agent cannot request more than the code carries.
-- **5-minute TTL** — the code expires 5 minutes after it is generated.
+- **10-minute TTL** — the code expires 10 minutes after it is generated.
 - **One-time use** — the code is consumed on first successful redemption and cannot be reused.
 - **Revocable anytime** — go to your Longbridge account security settings and revoke the **AI Agent** authorization to end access.
 
@@ -78,7 +78,7 @@ Follow least privilege: grant only the scopes the current task needs. For any tr
 
 ### The code has expired
 
-Auth codes are valid for 5 minutes. Return to [https://open.longbridge.com/connect](https://open.longbridge.com/connect) and generate a new one, then redeem it promptly.
+Auth codes are valid for 10 minutes. Return to [https://open.longbridge.com/connect](https://open.longbridge.com/connect) and generate a new one, then redeem it promptly.
 
 ### The code was already used
 

--- a/docs/zh-CN/docs/agent-auth.md
+++ b/docs/zh-CN/docs/agent-auth.md
@@ -34,7 +34,7 @@ sidebar_icon: sparkles
 4. **生成授权码** — 页面会生成一个简短的授权码和一段可直接粘贴的指令文本。
 5. **粘贴给 AI Agent** — 复制指令文本发送给助手，Agent 用下面任一方式兑换授权码。
 
-授权码有效期 **5 分钟**，且**仅可使用一次**。
+授权码有效期 **10 分钟**，且**仅可使用一次**。
 
 ## 通过 CLI 兑换
 
@@ -68,7 +68,7 @@ claude mcp add --transport http longbridge https://mcp.longbridge.com --header "
 ## 安全说明
 
 - **权限在网页端预选** — 授权码只能授予你在授权页勾选的权限，Agent 无法请求超出授权码携带范围的权限。
-- **5 分钟有效期** — 授权码在生成 5 分钟后过期。
+- **10 分钟有效期** — 授权码在生成 10 分钟后过期。
 - **一次性使用** — 授权码在首次成功兑换后即失效，不可重复使用。
 - **随时可撤销** — 前往 Longbridge 账户安全设置，撤销 **AI Agent** 授权即可终止访问。
 
@@ -78,7 +78,7 @@ claude mcp add --transport http longbridge https://mcp.longbridge.com --header "
 
 ### 授权码已过期
 
-授权码有效期为 5 分钟。回到 [https://open.longbridge.com/connect](https://open.longbridge.com/connect) 重新生成一个，并尽快兑换。
+授权码有效期为 10 分钟。回到 [https://open.longbridge.com/connect](https://open.longbridge.com/connect) 重新生成一个，并尽快兑换。
 
 ### 授权码已被使用
 

--- a/docs/zh-HK/docs/agent-auth.md
+++ b/docs/zh-HK/docs/agent-auth.md
@@ -34,7 +34,7 @@ sidebar_icon: sparkles
 4. **產生授權碼** — 頁面會產生一個簡短的授權碼和一段可直接貼上的指令文字。
 5. **貼給 AI Agent** — 複製指令文字傳送給助手，Agent 用下面任一方式兌換授權碼。
 
-授權碼有效期 **5 分鐘**，且**僅可使用一次**。
+授權碼有效期 **10 分鐘**，且**僅可使用一次**。
 
 ## 透過 CLI 兌換
 
@@ -68,7 +68,7 @@ claude mcp add --transport http longbridge https://mcp.longbridge.com --header "
 ## 安全說明
 
 - **權限在網頁端預選** — 授權碼只能授予你在授權頁勾選的權限，Agent 無法請求超出授權碼攜帶範圍的權限。
-- **5 分鐘有效期** — 授權碼在產生 5 分鐘後過期。
+- **10 分鐘有效期** — 授權碼在產生 10 分鐘後過期。
 - **一次性使用** — 授權碼在首次成功兌換後即失效，不可重複使用。
 - **隨時可撤銷** — 前往 Longbridge 帳戶安全設定，撤銷 **AI Agent** 授權即可終止存取。
 
@@ -78,7 +78,7 @@ claude mcp add --transport http longbridge https://mcp.longbridge.com --header "
 
 ### 授權碼已過期
 
-授權碼有效期為 5 分鐘。回到 [https://open.longbridge.com/connect](https://open.longbridge.com/connect) 重新產生一個，並盡快兌換。
+授權碼有效期為 10 分鐘。回到 [https://open.longbridge.com/connect](https://open.longbridge.com/connect) 重新產生一個，並盡快兌換。
 
 ### 授權碼已被使用
 


### PR DESCRIPTION
## Merge Verdict

**[APPROVE]** — Docs-only copy change; auth code TTL updated from 5 to 10 minutes, consistently applied across all three locales.

> 3 files · +9 / -9 · `docs/en` `docs/zh-CN` `docs/zh-HK`

---

## Change Summary

- Updates the AI Agent auth code TTL from **5 minutes** to **10 minutes** on the `agent-auth` page.
- All 3 mentions per file are covered: the intro statement, the Security bullet (`10-minute TTL`), and the "code has expired" troubleshooting note.
- Applied identically in `en` / `zh-CN` / `zh-HK`, satisfying the repo's trilingual sync rule.

---

## Risk Analysis

| Risk | Level | Mitigation |
|------|-------|------------|
| Docs drift from backend TTL | 🟡 | Requires the server-side auth code TTL to actually be 10 minutes; otherwise users will hit an expiry earlier than documented |
| Missed occurrences | ✅ | `grep` over `docs/` confirms no remaining "5 minutes / 5 分钟 / 5 分鐘" reference to the auth code TTL |
| Locale divergence | ✅ | Same 3 edits in all three locale files, verified line by line |

---

## Design Decisions

- **Terminology kept intact**: only the number changed; wording, bold markers and links are untouched, so translation parity is preserved.
- **Device-flow polling left alone**: `docs/{lang}/skill/install/index.md` mentions "~5 minutes" for the `auth login` device-code polling window — a different mechanism from the one-time auth code, correctly not modified.

---

## Code Concerns

1. **[需判断]** Docs change assumes the backend TTL is already 10 minutes (`docs/en/docs/agent-auth.md:37`)
   Docs are not the source of truth here; confirm the auth service has shipped the 10-minute TTL before merging, otherwise the page over-promises.

---

## Verification Status

✅ Markdown-only change · ✅ Trilingual sync verified · 📋 To verify: backend auth code TTL is actually 10 minutes
