### PR TITLE
docs(quote): refresh option Greek field descriptions on Calc Index

### DIFF
--- a/docs/en/docs/quote/analytics/calc-index.mdx
+++ b/docs/en/docs/quote/analytics/calc-index.mdx
@@ -281,12 +281,11 @@ func main() {
 | ∟ conversion_ratio         | string   | Conversion ratio                                                                          |
 | ∟ balance_point            | string   | Breakeven point                                                                           |
 | ∟ open_interest            | int64    | Open interest                                                                             |
-| ∟ delta                    | string   | Delta                                                                                     |
-| ∟ gamma                    | string   | Gamma                                                                                     |
-| ∟ theta                    | string   | Theta. Raw value needs to be divided by 100 to get the standard per-share per-day value   |
-| ∟ vega                     | string   | Vega. Raw value needs to be divided by 100 to get the standard per-share per-1%-IV value  |
-| ∟ rho                      | string   | Rho. Raw value needs to be divided by 100 to get the standard per-share per-1%-rate value |
-
+| ∟ delta                    | string   | Delta. Measures the expected change in option price for a $1 move in the underlying asset price. |
+| ∟ gamma                    | string   | Gamma. Measures the expected change in Delta for a $1 move in the underlying asset price. |
+| ∟ theta                    | string   | Theta. Measures the expected change in option price as one day passes; the raw value has been divided by 365 to convert to a daily value, representing the impact of one day's time decay on the option price. |
+| ∟ vega                     | string   | Vega. Measures the expected change in option price when implied volatility (IV) moves by 1 (i.e., 100%); divides the raw value by 100 to get the expected price change per 1% move in IV. |
+| ∟ rho                      | string   | Rho. Measures the expected change in option price when the risk-free interest rate moves by 1 (i.e., 100%); divides the raw value by 100 to get the expected price change per 1% move in the interest rate. |
 ### Protobuf
 
 ```protobuf

--- a/docs/zh-CN/docs/quote/analytics/calc-index.mdx
+++ b/docs/zh-CN/docs/quote/analytics/calc-index.mdx
@@ -267,12 +267,11 @@ func main() {
 | ∟ conversion_ratio         | string   | 换股比率                                     |
 | ∟ balance_point            | string   | 打和点                                       |
 | ∟ open_interest            | int64    | 未平仓数                                     |
-| ∟ delta                    | string   | Delta                                        |
-| ∟ gamma                    | string   | Gamma                                        |
-| ∟ theta                    | string   | Theta，原始值需除以 100 得到标准的每股每天值    |
-| ∟ vega                     | string   | Vega，原始值需除以 100 得到标准的每股每 1% IV 值 |
-| ∟ rho                      | string   | Rho，原始值需除以 100 得到标准的每股每 1% 利率值  |
-
+| ∟ delta                    | string   | Delta 值。衡量标的价格变动 $1 时，期权价格的预期变动量。 |
+| ∟ gamma                    | string   | Gamma 值。衡量标的价格变动 $1 时，Delta 的预期变动量。 |
+| ∟ theta                    | string   | Theta 值。衡量时间流逝一天时，期权价格的预期变动量；原始计算值已除以 365 换算为每日值，即每天的时间损耗对期权价格的影响。 |
+| ∟ vega                     | string   | Vega 值。衡量隐含波动率（IV）变动 1（即 100%）时，期权价格的预期变动量；如需衡量 IV 变动 1% 时的期权价格变动量，将原始值除以 100。 |
+| ∟ rho                      | string   | Rho 值。衡量无风险利率变动 1（即 100%）时，期权价格的预期变动量；如需衡量利率变动 1% 时的期权价格变动量，将原始值除以 100。 |
 ### Protobuf
 
 ```protobuf

--- a/docs/zh-HK/docs/quote/analytics/calc-index.mdx
+++ b/docs/zh-HK/docs/quote/analytics/calc-index.mdx
@@ -267,12 +267,11 @@ func main() {
 | ∟ conversion_ratio         | string   | 換股比率                                     |
 | ∟ balance_point            | string   | 打和點                                       |
 | ∟ open_interest            | int64    | 未平倉數                                     |
-| ∟ delta                    | string   | Delta                                        |
-| ∟ gamma                    | string   | Gamma                                        |
-| ∟ theta                    | string   | Theta，原始值需除以 100 得到標準的每股每天值    |
-| ∟ vega                     | string   | Vega，原始值需除以 100 得到標準的每股每 1% IV 值 |
-| ∟ rho                      | string   | Rho，原始值需除以 100 得到標準的每股每 1% 利率值  |
-
+| ∟ delta                    | string   | Delta 值。衡量標的價格變動 $1 時，期權價格的預期變動量。 |
+| ∟ gamma                    | string   | Gamma 值。衡量標的價格變動 $1 時，Delta 的預期變動量。 |
+| ∟ theta                    | string   | Theta 值。衡量時間流逝一天時，期權價格的預期變動量；原始計算值已除以 365 換算為每日值，即每天的時間損耗對期權價格的影響。 |
+| ∟ vega                     | string   | Vega 值。衡量隱含波動率（IV）變動 1（即 100%）時，期權價格的預期變動量；如需衡量 IV 變動 1% 時的期權價格變動量，將原始值除以 100。 |
+| ∟ rho                      | string   | Rho 值。衡量無風險利率變動 1（即 100%）時，期權價格的預期變動量；如需衡量利率變動 1% 時的期權價格變動量，將原始值除以 100。 |
 ### Protobuf
 
 ```protobuf


### PR DESCRIPTION
Update the delta / gamma / theta / vega / rho response-field descriptions on the Calc Index (calc_indexes) interface across all three languages (zh-CN / zh-HK / en).

Key change: **theta now documents the per-day semantics** — the raw value has been divided by 365 on the server to convert to a daily value (previously the docs incorrectly said divide by 100). delta/gamma get full descriptions; vega/rho reworded to the /100 form.

Source of truth: the 期权希腊字母 spec table. Matches the SDK (longbridge/openapi#586), MCP, and CLI changes.