### PR TITLE
fix(mdx): stop double-escaping angle brackets inside code

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -77,6 +77,21 @@ export default defineConfig({
             /<CliCommand>\r?\n([\s\S]*?)\r?\n[ \t]*<\/CliCommand>/g,
             (_m, inner: string) => `<CliCommand code={${JSON.stringify(inner)}} />`,
           )
+          // 1.6) Stash every code region: fenced blocks, inline spans, and the
+          //    CliCommand payload built just above. Their contents are literal
+          //    text that shiki escapes on its own, so the rewrites below must
+          //    not run over them — rule 5 turning `<iostream>` into `&lt;…&gt;`
+          //    gets escaped a second time downstream and the page renders the
+          //    entity text instead of the angle brackets. Fences are taken
+          //    before inline spans so a fence's own backticks are never read as
+          //    a span, and the CliCommand payload before both since it is a
+          //    JSON string that may itself contain backticks.
+          const codeRegions: string[] = []
+          const stashCode = (m: string) => `\uE000CODE${codeRegions.push(m) - 1}\uE000`
+          out = out
+            .replace(/<CliCommand code=\{"(?:[^"\\]|\\.)*"\} \/>/g, stashCode)
+            .replace(/^[ \t]*(`{3,}|~{3,})[^\n]*\n[\s\S]*?^[ \t]*\1[ \t]*$/gm, stashCode)
+            .replace(/`[^`\n]+`/g, stashCode)
           // 2) Convert vitepress heading anchor syntax `## Foo {#bar}` →
           //    `<h2 id="bar">Foo<a …/></h2>`.
           //    MDX parses `{#bar}` as a JSX expression (acorn) before remark plugins run,
@@ -147,6 +162,10 @@ export default defineConfig({
             /^(:{3,})(success|warning|tip|info|danger|note|caution)([ \t]+)([^\n[\]{]+?)\s*$/gm,
             (_match, colons, name, _ws, title) => `${colons}${name}[${title.trim()}]`,
           )
+          // Put back the code regions stashed in 1.6, now that every rewrite
+          //    above has run. Indices come from our own placeholders, so the
+          //    fallback is unreachable; it only keeps the lookup total.
+          out = out.replace(/\uE000CODE(\d+)\uE000/g, (_m, i) => codeRegions[Number(i)] ?? '')
           return out === code ? null : { code: out, map: null }
         },
       },


### PR DESCRIPTION
## Problem

The preflight rewrites in `astro.config.ts` run over the raw mdx source with code blocks included. Rule 5 turns `<iostream>` and `<token>` into `&lt;…&gt;`, the downstream pipeline escapes that a second time, and the page renders the entity text:

```
#include &lt;iostream&gt;          ← every C++ SDK example
Bearer &lt;token&gt;              ← every curl example
```

**419 pages** are affected. Anyone copying a snippet off the page gets broken code.

It is not only rule 5 — rules 6, 7, 9 and 10 rewrite code-region content too, so fixing a single rule is not enough.

## Fix

Stash the code regions before rules 2-10 run, restore them afterwards. Three kinds, and the order matters:

1. the `CliCommand` payload built in rule 1.5 (a JSON string that may itself contain backticks, so it goes first)
2. fenced blocks (before inline spans, or a fence's own backticks get read as a span)
3. inline code spans

The placeholder uses `U+E000` rather than `NUL` so oxlint's `no-control-regex` stays quiet.

## Verification

Against the dev server:

| check | result |
|---|---|
| C++ fence | `#include <iostream>` ✅ |
| curl fence | `Bearer <token>` ✅ |
| inline span | `<client_id>` ✅ |
| all 78 absolute-slug English pages | 200, no render failure |
| rule 9 REST placeholder | `/v1/content/{symbol}/news` unchanged |
| rule 1.5 CliCommand | terminal card unchanged |
| rule 10 directive | callout unchanged |
| oxlint | clean |

The regression checks matter most here: had the stash regex over-captured into prose, those placeholders would reach MDX as undefined components and the pages would 500. All 78 returning 200 confirms the prose-side escaping still works.