### PR TITLE
docs(market): fix Java getRankList example to use RankListOptions

### DIFF
--- a/docs/en/docs/market/status/rank_list.mdx
+++ b/docs/en/docs/market/status/rank_list.mdx
@@ -94,7 +94,10 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              MarketContext ctx = MarketContext.create(config)) {
-            var resp = ctx.getRankList("hot_all-us", false).get();
+            RankListOptions opts = new RankListOptions();
+            opts.key = "hot_all-us";
+            opts.needArticle = false;
+            var resp = ctx.getRankList(opts).get();
             System.out.println(resp);
         }
     }

--- a/docs/zh-CN/docs/market/status/rank_list.mdx
+++ b/docs/zh-CN/docs/market/status/rank_list.mdx
@@ -95,7 +95,10 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              MarketContext ctx = MarketContext.create(config)) {
-            var resp = ctx.getRankList("hot_all-us", false).get();
+            RankListOptions opts = new RankListOptions();
+            opts.key = "hot_all-us";
+            opts.needArticle = false;
+            var resp = ctx.getRankList(opts).get();
             System.out.println(resp);
         }
     }

--- a/docs/zh-HK/docs/market/status/rank_list.mdx
+++ b/docs/zh-HK/docs/market/status/rank_list.mdx
@@ -95,7 +95,10 @@ class Main {
         try (OAuth oauth = new OAuthBuilder("your-client-id").build(url -> System.out.println("Open to authorize: " + url)).get();
              Config config = Config.fromOAuth(oauth);
              MarketContext ctx = MarketContext.create(config)) {
-            var resp = ctx.getRankList("hot_all-us", false).get();
+            RankListOptions opts = new RankListOptions();
+            opts.key = "hot_all-us";
+            opts.needArticle = false;
+            var resp = ctx.getRankList(opts).get();
             System.out.println(resp);
         }
     }


### PR DESCRIPTION
Fixes #1249.

The Java example for the rank-list (人气排行榜) API called `ctx.getRankList("hot_all-us", false)` with positional args, but the Java API takes a `RankListOptions` object:

```java
RankListOptions opts = new RankListOptions();
opts.key = "hot_all-us";
opts.needArticle = false;
var resp = ctx.getRankList(opts).get();
```

Updated the Java example in all three languages (en / zh-CN / zh-HK). The Rust / Python / Node.js / C++ examples in the same page were already correct.

The accompanying runtime crash (`JNI call failed`) is fixed separately in longbridge/openapi#587.